### PR TITLE
Accessible language updates and Conversation Shape feature

### DIFF
--- a/src/app/api/og/default/route.tsx
+++ b/src/app/api/og/default/route.tsx
@@ -70,11 +70,11 @@ export async function GET() {
             borderTop: "2px solid #f4f4f5"
           }}>
             {[
-              { label: "Emotional Arousal", color: "#f43f5e", bg: "#fff1f2" }, // rose
-              { label: "Enemy Construction", color: "#6366f1", bg: "#eef2ff" }, // indigo
-              { label: "Moral Condemnation", color: "#f97316", bg: "#fff7ed" }, // orange/amber
-              { label: "Oversimplification", color: "#3b82f6", bg: "#eff6ff" }, // blue
-              { label: "Call-to-Conflict", color: "#f59e0b", bg: "#fffbeb" }, // amber
+              { label: "Emotional Heat", color: "#f43f5e", bg: "#fff1f2" }, // rose
+              { label: "Us vs Them", color: "#6366f1", bg: "#eef2ff" }, // indigo
+              { label: "Moral Outrage", color: "#f97316", bg: "#fff7ed" }, // orange/amber
+              { label: "Black & White Thinking", color: "#3b82f6", bg: "#eff6ff" }, // blue
+              { label: "Fight-Picking", color: "#f59e0b", bg: "#fffbeb" }, // amber
             ].map((signal) => (
               <div
                 key={signal.label}

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -23,7 +23,7 @@ export default function Methodology() {
           How RageCheck detects manipulative patterns in content.
         </p>
         <p className="text-sm text-zinc-500 dark:text-zinc-500 mb-12">
-          If you're seeing the "Techniques Detected," "Viral Triggers," or "How This Usually Plays Out" sections in a report, this page explains the model behind them.
+          If you're seeing the "Storytelling Choices," "Viral Triggers," or "How This Usually Plays Out" sections in a report, this page explains the model behind them.
         </p>
 
         {/* Overview */}
@@ -63,7 +63,7 @@ export default function Methodology() {
           <div className="space-y-3">
             <div className="p-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
               <div className="flex flex-col sm:flex-row sm:items-center gap-2">
-                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 sm:min-w-[180px]">Techniques Detected</span>
+                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 sm:min-w-[180px]">Storytelling Choices</span>
                 <span className="text-zinc-400 hidden sm:inline">→</span>
                 <span className="text-sm text-zinc-600 dark:text-zinc-400"><strong>Construction:</strong> Emotional Arousal, Moral Condemnation, Oversimplification</span>
               </div>

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -19,8 +19,11 @@ export default function Methodology() {
 
       <div className="max-w-4xl mx-auto px-4 py-12 md:py-20">
         <h1 className="text-4xl font-bold tracking-tight mb-4">Methodology</h1>
-        <p className="text-lg text-zinc-600 dark:text-zinc-400 mb-12">
+        <p className="text-lg text-zinc-600 dark:text-zinc-400 mb-4">
           How RageCheck detects manipulative patterns in content.
+        </p>
+        <p className="text-sm text-zinc-500 dark:text-zinc-500 mb-12">
+          If you're seeing the "Techniques Detected," "Viral Triggers," or "How This Usually Plays Out" sections in a report, this page explains the model behind them.
         </p>
 
         {/* Overview */}
@@ -33,9 +36,53 @@ export default function Methodology() {
           </p>
           <p className="text-zinc-600 dark:text-zinc-400 leading-relaxed">
             The system analyzes text for linguistic patterns commonly associated with manipulative
-            framing—language designed to provoke emotional reactions rather than inform. It does not
+            framing—language optimized to provoke high-arousal reactions over understanding. It does not
             assess factual accuracy or political bias.
           </p>
+        </section>
+
+        {/* Why this breakdown */}
+        <section className="mb-12">
+          <h2 className="text-2xl font-bold mb-4">Why This Breakdown</h2>
+          <p className="text-zinc-600 dark:text-zinc-400 leading-relaxed mb-4">
+            RageCheck organizes analysis the same way influence typically works in the real world:
+          </p>
+          <ol className="list-decimal list-inside text-zinc-600 dark:text-zinc-400 space-y-2 ml-4 mb-6">
+            <li><strong>How content is constructed</strong> — tone, framing, rhetoric</li>
+            <li><strong>Why it spreads</strong> — share mechanics, identity signaling, conflict cues</li>
+            <li><strong>How it tends to affect people</strong> — likely emotional intensity and discussion style</li>
+          </ol>
+
+          <div className="p-4 bg-zinc-100 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700 rounded-lg mb-6">
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+              <strong>Note:</strong> This is probabilistic pattern detection. It does not infer intent and it is not truth scoring. It estimates patterns that tend to correlate with higher-arousal, lower-nuance media.
+            </p>
+          </div>
+
+          <h3 className="font-bold text-lg mb-3">How the UI Sections Map to Signals</h3>
+          <div className="space-y-3">
+            <div className="p-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 sm:min-w-[180px]">Techniques Detected</span>
+                <span className="text-zinc-400 hidden sm:inline">→</span>
+                <span className="text-sm text-zinc-600 dark:text-zinc-400"><strong>Construction:</strong> Emotional Arousal, Moral Condemnation, Oversimplification</span>
+              </div>
+            </div>
+            <div className="p-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 sm:min-w-[180px]">Viral Triggers</span>
+                <span className="text-zinc-400 hidden sm:inline">→</span>
+                <span className="text-sm text-zinc-600 dark:text-zinc-400"><strong>Transmission:</strong> Call-to-Conflict, Enemy Construction</span>
+              </div>
+            </div>
+            <div className="p-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 sm:min-w-[180px]">How This Usually Plays Out</span>
+                <span className="text-zinc-400 hidden sm:inline">→</span>
+                <span className="text-sm text-zinc-600 dark:text-zinc-400"><strong>Impact:</strong> Combined signal read predicting likely reaction patterns</span>
+              </div>
+            </div>
+          </div>
         </section>
 
         {/* Signal Categories */}

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -65,14 +65,14 @@ export default function Methodology() {
               <div className="flex flex-col sm:flex-row sm:items-center gap-2">
                 <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 sm:min-w-[180px]">Techniques Detected</span>
                 <span className="text-zinc-400 hidden sm:inline">→</span>
-                <span className="text-sm text-zinc-600 dark:text-zinc-400"><strong>Construction:</strong> Emotional Arousal, Moral Condemnation, Oversimplification</span>
+                <span className="text-sm text-zinc-600 dark:text-zinc-400"><strong>Construction:</strong> Emotional Heat, Moral Outrage, Black & White Thinking</span>
               </div>
             </div>
             <div className="p-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
               <div className="flex flex-col sm:flex-row sm:items-center gap-2">
                 <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 sm:min-w-[180px]">Viral Triggers</span>
                 <span className="text-zinc-400 hidden sm:inline">→</span>
-                <span className="text-sm text-zinc-600 dark:text-zinc-400"><strong>Transmission:</strong> Call-to-Conflict, Enemy Construction</span>
+                <span className="text-sm text-zinc-600 dark:text-zinc-400"><strong>Transmission:</strong> Fight-Picking, Us vs Them</span>
               </div>
             </div>
             <div className="p-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
@@ -95,7 +95,7 @@ export default function Methodology() {
 
           <div className="space-y-6">
             <div className="p-6 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
-              <h3 className="font-bold text-lg mb-2 text-rose-600 dark:text-rose-400">Emotional Arousal</h3>
+              <h3 className="font-bold text-lg mb-2 text-rose-600 dark:text-rose-400">Emotional Heat</h3>
               <p className="text-zinc-600 dark:text-zinc-400 leading-relaxed mb-3">
                 Language designed to activate strong emotional responses—fear, anger, disgust, or outrage—rather than inform.
               </p>
@@ -106,7 +106,7 @@ export default function Methodology() {
             </div>
 
             <div className="p-6 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
-              <h3 className="font-bold text-lg mb-2 text-indigo-600 dark:text-indigo-400">Enemy Construction</h3>
+              <h3 className="font-bold text-lg mb-2 text-indigo-600 dark:text-indigo-400">Us vs Them</h3>
               <p className="text-zinc-600 dark:text-zinc-400 leading-relaxed mb-3">
                 Framing that constructs an adversary—dehumanizing groups, attributing malicious intent,
                 or creating artificial us-vs-them divisions.
@@ -118,7 +118,7 @@ export default function Methodology() {
             </div>
 
             <div className="p-6 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
-              <h3 className="font-bold text-lg mb-2 text-orange-600 dark:text-orange-400">Moral Condemnation</h3>
+              <h3 className="font-bold text-lg mb-2 text-orange-600 dark:text-orange-400">Moral Outrage</h3>
               <p className="text-zinc-600 dark:text-zinc-400 leading-relaxed mb-3">
                 Appeals to moral outrage, purity rhetoric, and righteous indignation that frame issues
                 as battles between good and evil.
@@ -130,7 +130,7 @@ export default function Methodology() {
             </div>
 
             <div className="p-6 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
-              <h3 className="font-bold text-lg mb-2 text-blue-600 dark:text-blue-400">Oversimplification</h3>
+              <h3 className="font-bold text-lg mb-2 text-blue-600 dark:text-blue-400">Black & White Thinking</h3>
               <p className="text-zinc-600 dark:text-zinc-400 leading-relaxed mb-3">
                 Black-and-white framing that eliminates nuance, presents false dichotomies, or reduces
                 complex issues to simple narratives.
@@ -142,7 +142,7 @@ export default function Methodology() {
             </div>
 
             <div className="p-6 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-xl">
-              <h3 className="font-bold text-lg mb-2 text-amber-600 dark:text-amber-400">Call-to-Conflict</h3>
+              <h3 className="font-bold text-lg mb-2 text-amber-600 dark:text-amber-400">Fight-Picking</h3>
               <p className="text-zinc-600 dark:text-zinc-400 leading-relaxed mb-3">
                 Direct provocations, engagement bait, and language designed to mobilize action or
                 spread content virally.
@@ -243,11 +243,11 @@ export default function Methodology() {
             propaganda studies, and affective computing:
           </p>
           <ul className="list-disc list-inside text-zinc-600 dark:text-zinc-400 space-y-2 ml-4">
-            <li><strong>Emotional Arousal</strong> — Based on dimensional models of emotion (Russell, 1980) and research on emotional contagion in social media (Kramer et al., 2014)</li>
-            <li><strong>Enemy Construction</strong> — Draws from intergroup conflict theory (Tajfel & Turner, 1979) and research on dehumanization (Haslam, 2006)</li>
-            <li><strong>Moral Condemnation</strong> — Informed by moral foundations theory (Haidt & Graham, 2007) and research on moral outrage online (Crockett, 2017)</li>
-            <li><strong>Oversimplification</strong> — Based on research on cognitive biases and the appeal of simple narratives (Kahneman, 2011)</li>
-            <li><strong>Call-to-Conflict</strong> — Draws from propaganda analysis frameworks (Ellul, 1965) and research on viral content dynamics (Berger & Milkman, 2012)</li>
+            <li><strong>Emotional Heat</strong> — Based on dimensional models of emotion (Russell, 1980) and research on emotional contagion in social media (Kramer et al., 2014)</li>
+            <li><strong>Us vs Them</strong> — Draws from intergroup conflict theory (Tajfel & Turner, 1979) and research on dehumanization (Haslam, 2006)</li>
+            <li><strong>Moral Outrage</strong> — Informed by moral foundations theory (Haidt & Graham, 2007) and research on moral outrage online (Crockett, 2017)</li>
+            <li><strong>Black & White Thinking</strong> — Based on research on cognitive biases and the appeal of simple narratives (Kahneman, 2011)</li>
+            <li><strong>Fight-Picking</strong> — Draws from propaganda analysis frameworks (Ellul, 1965) and research on viral content dynamics (Berger & Milkman, 2012)</li>
           </ul>
         </section>
 

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -23,7 +23,7 @@ export default function Methodology() {
           How RageCheck detects manipulative patterns in content.
         </p>
         <p className="text-sm text-zinc-500 dark:text-zinc-500 mb-12">
-          If you're seeing the "Storytelling Choices," "Viral Triggers," or "How This Usually Plays Out" sections in a report, this page explains the model behind them.
+          If you're seeing the "Techniques Detected," "Viral Triggers," or "How This Usually Plays Out" sections in a report, this page explains the model behind them.
         </p>
 
         {/* Overview */}
@@ -63,7 +63,7 @@ export default function Methodology() {
           <div className="space-y-3">
             <div className="p-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
               <div className="flex flex-col sm:flex-row sm:items-center gap-2">
-                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 sm:min-w-[180px]">Storytelling Choices</span>
+                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 sm:min-w-[180px]">Techniques Detected</span>
                 <span className="text-zinc-400 hidden sm:inline">→</span>
                 <span className="text-sm text-zinc-600 dark:text-zinc-400"><strong>Construction:</strong> Emotional Arousal, Moral Condemnation, Oversimplification</span>
               </div>

--- a/src/app/methodology/page.tsx
+++ b/src/app/methodology/page.tsx
@@ -23,7 +23,7 @@ export default function Methodology() {
           How RageCheck detects manipulative patterns in content.
         </p>
         <p className="text-sm text-zinc-500 dark:text-zinc-500 mb-12">
-          If you're seeing the "Techniques Detected," "Viral Triggers," or "How This Usually Plays Out" sections in a report, this page explains the model behind them.
+          If you're seeing the "Techniques Detected," "Viral Triggers," or "What Follows" sections in a report, this page explains the model behind them.
         </p>
 
         {/* Overview */}
@@ -77,7 +77,7 @@ export default function Methodology() {
             </div>
             <div className="p-4 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-lg">
               <div className="flex flex-col sm:flex-row sm:items-center gap-2">
-                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 sm:min-w-[180px]">How This Usually Plays Out</span>
+                <span className="text-sm font-semibold text-zinc-900 dark:text-zinc-100 sm:min-w-[180px]">What Follows</span>
                 <span className="text-zinc-400 hidden sm:inline">→</span>
                 <span className="text-sm text-zinc-600 dark:text-zinc-400"><strong>Impact:</strong> Combined signal read predicting likely reaction patterns</span>
               </div>

--- a/src/app/model/page.tsx
+++ b/src/app/model/page.tsx
@@ -32,11 +32,11 @@ interface AnalysisResult {
 
 // Bar display configuration
 const BAR_CONFIG = {
-  arousal: { label: "Arousal", color: "bg-red-500", description: "Emotional intensity & urgency" },
-  enemy_construction: { label: "Enemy Construction", color: "bg-orange-500", description: "Othering & dehumanization" },
-  moral_condemnation: { label: "Moral Condemnation", color: "bg-purple-500", description: "Moral outrage & purity" },
-  simplification: { label: "Simplification", color: "bg-yellow-500", description: "Black-and-white thinking" },
-  call_to_conflict: { label: "Call to Conflict", color: "bg-pink-500", description: "Engagement bait & provocation" },
+  arousal: { label: "Emotional Heat", color: "bg-red-500", description: "Emotional intensity & urgency" },
+  enemy_construction: { label: "Us vs Them", color: "bg-orange-500", description: "Othering & dehumanization" },
+  moral_condemnation: { label: "Moral Outrage", color: "bg-purple-500", description: "Moral outrage & purity" },
+  simplification: { label: "Black & White Thinking", color: "bg-yellow-500", description: "Black-and-white thinking" },
+  call_to_conflict: { label: "Fight-Picking", color: "bg-pink-500", description: "Engagement bait & provocation" },
 };
 
 function ScoreGauge({ score, label }: { score: number; label: string }) {
@@ -391,11 +391,11 @@ export default function ModelPage() {
                 No single word triggers a high score—patterns must combine.
               </p>
               <ul className="space-y-1">
-                <li><strong>Arousal:</strong> Emotional intensity, urgency, punctuation</li>
-                <li><strong>Enemy Construction:</strong> Othering, dehumanization, scapegoating</li>
-                <li><strong>Moral Condemnation:</strong> Moral judgment, purity rhetoric</li>
-                <li><strong>Simplification:</strong> Absolutism, false dilemmas</li>
-                <li><strong>Call to Conflict:</strong> Engagement bait, provocation</li>
+                <li><strong>Emotional Heat:</strong> Emotional intensity, urgency, punctuation</li>
+                <li><strong>Us vs Them:</strong> Othering, dehumanization, scapegoating</li>
+                <li><strong>Moral Outrage:</strong> Moral judgment, purity rhetoric</li>
+                <li><strong>Black & White Thinking:</strong> Absolutism, false dilemmas</li>
+                <li><strong>Fight-Picking:</strong> Engagement bait, provocation</li>
               </ul>
             </div>
             <div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1327,7 +1327,7 @@ function HomeContent() {
                     {result.llmEnhanced && result.techniqueExplanations && result.techniqueExplanations.length > 0 && (
                       <div className="mt-8 pt-6 border-t border-zinc-100 dark:border-zinc-800 w-full text-left">
                         <h4 className="text-xs font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-4">
-                          Techniques Detected
+                          Storytelling Choices
                         </h4>
                         <div className="space-y-3">
                           {result.techniqueExplanations.map((technique, i) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import { getScoreBucket } from "@/lib/share";
 import { SIGNAL_LABELS } from "@/lib/shareCard";
 import { copyShareImageToClipboard } from "@/lib/shareImage";
 import * as tracking from "@/lib/tracking";
-import { detectConversationShape, ConversationShape } from "@/lib/conversationShape";
 
 interface Highlight {
   start: number;
@@ -577,17 +576,6 @@ function HomeContent() {
   const [imageCopied, setImageCopied] = useState(false);
   const [feedbackGiven, setFeedbackGiven] = useState<"up" | "down" | null>(null);
   const [feedbackComment, setFeedbackComment] = useState("");
-
-  // Conversation shape detection
-  const conversationShape = useMemo<ConversationShape | null>(() => {
-    if (!result?.success || !result.signalBreakdown) return null;
-    return detectConversationShape({
-      signalBreakdown: result.signalBreakdown,
-      techniqueExplanations: result.techniqueExplanations,
-      sharingPatterns: result.sharingPatterns,
-      score: result.score,
-    });
-  }, [result]);
 
   const [showFeedbackForm, setShowFeedbackForm] = useState(false);
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
@@ -1358,32 +1346,6 @@ function HomeContent() {
                       </div>
                     )}
 
-                    {/* What Follows */}
-                    {conversationShape && (
-                      <div className="mt-8 pt-6 border-t border-zinc-100 dark:border-zinc-800 w-full text-left">
-                        <h4 className="text-xs font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-4">
-                          What Follows
-                        </h4>
-                        <div className="space-y-3">
-                          <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
-                            {conversationShape.displayLabel}
-                          </p>
-                          <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
-                            {conversationShape.explanation}
-                          </p>
-                          {conversationShape.microSignals.length > 0 && (
-                            <div className="mt-3 space-y-1.5">
-                              {conversationShape.microSignals.map((signal, i) => (
-                                <div key={i} className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
-                                  <span className="w-1 h-1 rounded-full bg-zinc-400 dark:bg-zinc-500" />
-                                  <span>{signal}</span>
-                                </div>
-                              ))}
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    )}
                   </div>
                 </BentoCard>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,15 @@ import { getScoreBucket } from "@/lib/share";
 import { SIGNAL_LABELS } from "@/lib/shareCard";
 import { copyShareImageToClipboard } from "@/lib/shareImage";
 import * as tracking from "@/lib/tracking";
+import {
+  computeAsymmetricValue,
+  generateSharecards,
+  adaptAnalysisToInput,
+  AsymmetricValueOutput,
+  SharecardOutput,
+} from "@/lib/asymmetricValue";
+import { AsymmetricValuePanel } from "@/components/AsymmetricValuePanel";
+import { SharecardSelector } from "@/components/SharecardSelector";
 
 interface Highlight {
   start: number;
@@ -576,6 +585,37 @@ function HomeContent() {
   const [imageCopied, setImageCopied] = useState(false);
   const [feedbackGiven, setFeedbackGiven] = useState<"up" | "down" | null>(null);
   const [feedbackComment, setFeedbackComment] = useState("");
+
+  // Asymmetric Value computation
+  const asymmetricValueData = useMemo<{ output: AsymmetricValueOutput; sharecards: SharecardOutput } | null>(() => {
+    if (!result?.success || !result.signalBreakdown) return null;
+    try {
+      const input = adaptAnalysisToInput(url, {
+        score: result.score,
+        signalBreakdown: result.signalBreakdown,
+        title: result.title,
+        sourceDomain: result.sourceDomain,
+        textPreview: result.textPreview,
+        highlights: result.highlights,
+        reasons: result.reasons,
+        techniqueExplanations: result.techniqueExplanations,
+        sharingPatterns: result.sharingPatterns,
+      });
+      const output = computeAsymmetricValue(input);
+      const sharecards = generateSharecards(
+        output.forecast,
+        output.heat_vs_evidence,
+        output.verification_checks,
+        output.low_regret_action,
+        input.original_url,
+        input.content_type
+      );
+      return { output, sharecards };
+    } catch (error) {
+      console.error("Failed to compute asymmetric value:", error);
+      return null;
+    }
+  }, [result, url]);
   const [showFeedbackForm, setShowFeedbackForm] = useState(false);
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
   const [errorReported, setErrorReported] = useState(false);
@@ -1469,6 +1509,23 @@ function HomeContent() {
                       </div>
                     )}
                   </BentoCard>
+
+                  {/* Asymmetric Value Panel */}
+                  {asymmetricValueData && !isDemo && (
+                    <BentoCard title="">
+                      <AsymmetricValuePanel data={asymmetricValueData.output} />
+                    </BentoCard>
+                  )}
+
+                  {/* Share Card Selector */}
+                  {asymmetricValueData && !isDemo && (
+                    <BentoCard title="">
+                      <SharecardSelector
+                        sharecards={asymmetricValueData.sharecards}
+                        resultUrl={getShareUrl()}
+                      />
+                    </BentoCard>
+                  )}
                 </div>
               </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1331,8 +1331,8 @@ function HomeContent() {
                         </h4>
                         <div className="space-y-3">
                           {result.techniqueExplanations.map((technique, i) => (
-                            <div key={i} className="flex gap-3">
-                              <div className="mt-1 w-1.5 h-1.5 rounded-full bg-rose-400 flex-shrink-0" />
+                            <div key={i} className="flex gap-3 items-start">
+                              <div className="mt-1.5 w-1.5 h-1.5 rounded-full bg-zinc-400 dark:bg-zinc-500 flex-shrink-0" />
                               <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-snug">{technique}</p>
                             </div>
                           ))}
@@ -1348,9 +1348,7 @@ function HomeContent() {
                         <div className="space-y-3">
                           {result.sharingPatterns.map((pattern, i) => (
                             <div key={i} className="flex gap-3 items-start">
-                              <span className="flex-shrink-0 w-5 h-5 rounded-full bg-indigo-100 dark:bg-indigo-900/30 flex items-center justify-center text-indigo-600 dark:text-indigo-400 text-[10px] font-bold">
-                                {i + 1}
-                              </span>
+                              <div className="mt-1.5 w-1.5 h-1.5 rounded-full bg-zinc-400 dark:bg-zinc-500 flex-shrink-0" />
                               <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-snug">{pattern}</p>
                             </div>
                           ))}
@@ -1364,9 +1362,6 @@ function HomeContent() {
                         <div className="space-y-3">
                           <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
                             {conversationShape.displayLabel}
-                          </p>
-                          <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
-                            {conversationShape.explanation}
                           </p>
                           {conversationShape.microSignals.length > 0 && (
                             <div className="mt-3 space-y-1.5">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,15 +6,6 @@ import { getScoreBucket } from "@/lib/share";
 import { SIGNAL_LABELS } from "@/lib/shareCard";
 import { copyShareImageToClipboard } from "@/lib/shareImage";
 import * as tracking from "@/lib/tracking";
-import {
-  computeAsymmetricValue,
-  generateSharecards,
-  adaptAnalysisToInput,
-  AsymmetricValueOutput,
-  SharecardOutput,
-} from "@/lib/asymmetricValue";
-import { AsymmetricValuePanel } from "@/components/AsymmetricValuePanel";
-import { SharecardSelector } from "@/components/SharecardSelector";
 import { detectConversationShape, ConversationShape } from "@/lib/conversationShape";
 
 interface Highlight {
@@ -586,37 +577,6 @@ function HomeContent() {
   const [imageCopied, setImageCopied] = useState(false);
   const [feedbackGiven, setFeedbackGiven] = useState<"up" | "down" | null>(null);
   const [feedbackComment, setFeedbackComment] = useState("");
-
-  // Asymmetric Value computation
-  const asymmetricValueData = useMemo<{ output: AsymmetricValueOutput; sharecards: SharecardOutput } | null>(() => {
-    if (!result?.success || !result.signalBreakdown) return null;
-    try {
-      const input = adaptAnalysisToInput(url, {
-        score: result.score,
-        signalBreakdown: result.signalBreakdown,
-        title: result.title,
-        sourceDomain: result.sourceDomain,
-        textPreview: result.textPreview,
-        highlights: result.highlights,
-        reasons: result.reasons,
-        techniqueExplanations: result.techniqueExplanations,
-        sharingPatterns: result.sharingPatterns,
-      });
-      const output = computeAsymmetricValue(input);
-      const sharecards = generateSharecards(
-        output.forecast,
-        output.heat_vs_evidence,
-        output.verification_checks,
-        output.low_regret_action,
-        input.original_url,
-        input.content_type
-      );
-      return { output, sharecards };
-    } catch (error) {
-      console.error("Failed to compute asymmetric value:", error);
-      return null;
-    }
-  }, [result, url]);
 
   // Conversation shape detection
   const conversationShape = useMemo<ConversationShape | null>(() => {
@@ -1549,23 +1509,6 @@ function HomeContent() {
                       </div>
                     )}
                   </BentoCard>
-
-                  {/* Asymmetric Value Panel */}
-                  {asymmetricValueData && !isDemo && (
-                    <BentoCard title="">
-                      <AsymmetricValuePanel data={asymmetricValueData.output} />
-                    </BentoCard>
-                  )}
-
-                  {/* Share Card Selector */}
-                  {asymmetricValueData && !isDemo && (
-                    <BentoCard title="">
-                      <SharecardSelector
-                        sharecards={asymmetricValueData.sharecards}
-                        resultUrl={getShareUrl()}
-                      />
-                    </BentoCard>
-                  )}
                 </div>
               </div>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1358,12 +1358,9 @@ function HomeContent() {
                       </div>
                     )}
 
-                    {/* What Follows */}
+                    {/* Conversation Shape */}
                     {conversationShape && (
                       <div className="mt-8 pt-6 border-t border-zinc-100 dark:border-zinc-800 w-full text-left">
-                        <h4 className="text-xs font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-4">
-                          What Follows
-                        </h4>
                         <div className="space-y-3">
                           <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
                             {conversationShape.displayLabel}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { getScoreBucket } from "@/lib/share";
 import { SIGNAL_LABELS } from "@/lib/shareCard";
 import { copyShareImageToClipboard } from "@/lib/shareImage";
 import * as tracking from "@/lib/tracking";
+import { detectConversationShape, ConversationShape } from "@/lib/conversationShape";
 
 interface Highlight {
   start: number;
@@ -576,6 +577,17 @@ function HomeContent() {
   const [imageCopied, setImageCopied] = useState(false);
   const [feedbackGiven, setFeedbackGiven] = useState<"up" | "down" | null>(null);
   const [feedbackComment, setFeedbackComment] = useState("");
+
+  // Conversation shape detection
+  const conversationShape = useMemo<ConversationShape | null>(() => {
+    if (!result?.success || !result.signalBreakdown) return null;
+    return detectConversationShape({
+      signalBreakdown: result.signalBreakdown,
+      techniqueExplanations: result.techniqueExplanations,
+      sharingPatterns: result.sharingPatterns,
+      score: result.score,
+    });
+  }, [result]);
 
   const [showFeedbackForm, setShowFeedbackForm] = useState(false);
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
@@ -1346,6 +1358,32 @@ function HomeContent() {
                       </div>
                     )}
 
+                    {/* What Follows */}
+                    {conversationShape && (
+                      <div className="mt-8 pt-6 border-t border-zinc-100 dark:border-zinc-800 w-full text-left">
+                        <h4 className="text-xs font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-4">
+                          What Follows
+                        </h4>
+                        <div className="space-y-3">
+                          <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
+                            {conversationShape.displayLabel}
+                          </p>
+                          <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+                            {conversationShape.explanation}
+                          </p>
+                          {conversationShape.microSignals.length > 0 && (
+                            <div className="mt-3 space-y-1.5">
+                              {conversationShape.microSignals.map((signal, i) => (
+                                <div key={i} className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+                                  <span className="w-1 h-1 rounded-full bg-zinc-400 dark:bg-zinc-500" />
+                                  <span>{signal}</span>
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </BentoCard>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1358,11 +1358,11 @@ function HomeContent() {
                       </div>
                     )}
 
-                    {/* How This Usually Plays Out */}
+                    {/* What Follows */}
                     {conversationShape && (
                       <div className="mt-8 pt-6 border-t border-zinc-100 dark:border-zinc-800 w-full text-left">
                         <h4 className="text-xs font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-4">
-                          How This Usually Plays Out
+                          What Follows
                         </h4>
                         <div className="space-y-3">
                           <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1324,6 +1324,15 @@ function HomeContent() {
                        </div>
                     </div>
 
+                    {/* Summary */}
+                    {result.shareCardSummary && (
+                      <div className="mt-8 pt-6 border-t border-zinc-100 dark:border-zinc-800 w-full text-left">
+                        <p className="text-base text-zinc-700 dark:text-zinc-300 leading-relaxed">
+                          {result.shareCardSummary}
+                        </p>
+                      </div>
+                    )}
+
                     {result.llmEnhanced && result.techniqueExplanations && result.techniqueExplanations.length > 0 && (
                       <div className="mt-8 pt-6 border-t border-zinc-100 dark:border-zinc-800 w-full text-left">
                         <h4 className="text-xs font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -535,7 +535,7 @@ function MicroDemoCard() {
               <div className="flex-1 space-y-2.5">
                  <div className="space-y-1">
                     <div className="flex justify-between text-[9px] uppercase font-bold text-zinc-500 tracking-wider">
-                       <span>Enemy Construction</span>
+                       <span>Us vs Them</span>
                        <span>85%</span>
                     </div>
                     <div className="h-1.5 bg-zinc-200 dark:bg-zinc-700 rounded-full overflow-hidden">
@@ -544,7 +544,7 @@ function MicroDemoCard() {
                  </div>
                  <div className="space-y-1">
                     <div className="flex justify-between text-[9px] uppercase font-bold text-zinc-500 tracking-wider">
-                       <span>Emotional Arousal</span>
+                       <span>Emotional Heat</span>
                        <span>72%</span>
                     </div>
                     <div className="h-1.5 bg-zinc-200 dark:bg-zinc-700 rounded-full overflow-hidden">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1327,7 +1327,7 @@ function HomeContent() {
                     {result.llmEnhanced && result.techniqueExplanations && result.techniqueExplanations.length > 0 && (
                       <div className="mt-8 pt-6 border-t border-zinc-100 dark:border-zinc-800 w-full text-left">
                         <h4 className="text-xs font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-4">
-                          Storytelling Choices
+                          Techniques Detected
                         </h4>
                         <div className="space-y-3">
                           {result.techniqueExplanations.map((technique, i) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/lib/asymmetricValue";
 import { AsymmetricValuePanel } from "@/components/AsymmetricValuePanel";
 import { SharecardSelector } from "@/components/SharecardSelector";
+import { detectConversationShape, ConversationShape } from "@/lib/conversationShape";
 
 interface Highlight {
   start: number;
@@ -616,6 +617,18 @@ function HomeContent() {
       return null;
     }
   }, [result, url]);
+
+  // Conversation shape detection
+  const conversationShape = useMemo<ConversationShape | null>(() => {
+    if (!result?.success || !result.signalBreakdown) return null;
+    return detectConversationShape({
+      signalBreakdown: result.signalBreakdown,
+      techniqueExplanations: result.techniqueExplanations,
+      sharingPatterns: result.sharingPatterns,
+      score: result.score,
+    });
+  }, [result]);
+
   const [showFeedbackForm, setShowFeedbackForm] = useState(false);
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
   const [errorReported, setErrorReported] = useState(false);
@@ -1381,6 +1394,33 @@ function HomeContent() {
                               <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-snug">{pattern}</p>
                             </div>
                           ))}
+                        </div>
+                      </div>
+                    )}
+
+                    {/* How This Usually Plays Out */}
+                    {conversationShape && (
+                      <div className="mt-8 pt-6 border-t border-zinc-100 dark:border-zinc-800 w-full text-left">
+                        <h4 className="text-xs font-bold uppercase tracking-wider text-zinc-500 dark:text-zinc-400 mb-4">
+                          How This Usually Plays Out
+                        </h4>
+                        <div className="space-y-3">
+                          <p className="text-base font-semibold text-zinc-900 dark:text-zinc-100">
+                            {conversationShape.displayLabel}
+                          </p>
+                          <p className="text-sm text-zinc-600 dark:text-zinc-400 leading-relaxed">
+                            {conversationShape.explanation}
+                          </p>
+                          {conversationShape.microSignals.length > 0 && (
+                            <div className="mt-3 space-y-1.5">
+                              {conversationShape.microSignals.map((signal, i) => (
+                                <div key={i} className="flex items-center gap-2 text-xs text-zinc-500 dark:text-zinc-400">
+                                  <span className="w-1 h-1 rounded-full bg-zinc-400 dark:bg-zinc-500" />
+                                  <span>{signal}</span>
+                                </div>
+                              ))}
+                            </div>
+                          )}
                         </div>
                       </div>
                     )}

--- a/src/components/AsymmetricValuePanel.tsx
+++ b/src/components/AsymmetricValuePanel.tsx
@@ -1,0 +1,454 @@
+"use client";
+
+import { useState } from "react";
+import { AsymmetricValueOutput } from "@/lib/asymmetricValue/types";
+
+interface AsymmetricValuePanelProps {
+  data: AsymmetricValueOutput;
+}
+
+// ============================================
+// ICONS
+// ============================================
+
+function ForecastIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6" />
+    </svg>
+  );
+}
+
+function HeatIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10c0-2 .5-5 2.986-7C14 5 16.09 5.777 17.656 7.343A7.975 7.975 0 0120 13a7.975 7.975 0 01-2.343 5.657z" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 16.121A3 3 0 1012.015 11L11 14H9c0 .768.293 1.536.879 2.121z" />
+    </svg>
+  );
+}
+
+function VerifyIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+    </svg>
+  );
+}
+
+function FingerprintIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 11c0 3.517-1.009 6.799-2.753 9.571m-3.44-2.04l.054-.09A13.916 13.916 0 008 11a4 4 0 118 0c0 1.017-.07 2.019-.203 3m-2.118 6.844A21.88 21.88 0 0015.171 17m3.839 1.132c.645-2.266.99-4.659.99-7.132A8 8 0 008 4.07M3 15.364c.64-1.319 1-2.8 1-4.364 0-1.457.39-2.823 1.07-4" />
+    </svg>
+  );
+}
+
+function TemplateIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
+    </svg>
+  );
+}
+
+function ActionIcon() {
+  return (
+    <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+    </svg>
+  );
+}
+
+function ChevronIcon({ expanded }: { expanded: boolean }) {
+  return (
+    <svg
+      className={`w-4 h-4 transition-transform ${expanded ? "rotate-180" : ""}`}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+    </svg>
+  );
+}
+
+// ============================================
+// ACCORDION BLOCK
+// ============================================
+
+interface BlockProps {
+  icon: React.ReactNode;
+  title: string;
+  badge?: React.ReactNode;
+  children: React.ReactNode;
+  explainItems: string[];
+  accentColor?: string;
+}
+
+function Block({ icon, title, badge, children, explainItems, accentColor = "indigo" }: BlockProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const colorClasses: Record<string, { border: string; bg: string; text: string; icon: string }> = {
+    indigo: {
+      border: "border-indigo-200 dark:border-indigo-800",
+      bg: "bg-indigo-50 dark:bg-indigo-900/20",
+      text: "text-indigo-700 dark:text-indigo-300",
+      icon: "text-indigo-500 dark:text-indigo-400",
+    },
+    amber: {
+      border: "border-amber-200 dark:border-amber-800",
+      bg: "bg-amber-50 dark:bg-amber-900/20",
+      text: "text-amber-700 dark:text-amber-300",
+      icon: "text-amber-500 dark:text-amber-400",
+    },
+    emerald: {
+      border: "border-emerald-200 dark:border-emerald-800",
+      bg: "bg-emerald-50 dark:bg-emerald-900/20",
+      text: "text-emerald-700 dark:text-emerald-300",
+      icon: "text-emerald-500 dark:text-emerald-400",
+    },
+    rose: {
+      border: "border-rose-200 dark:border-rose-800",
+      bg: "bg-rose-50 dark:bg-rose-900/20",
+      text: "text-rose-700 dark:text-rose-300",
+      icon: "text-rose-500 dark:text-rose-400",
+    },
+    purple: {
+      border: "border-purple-200 dark:border-purple-800",
+      bg: "bg-purple-50 dark:bg-purple-900/20",
+      text: "text-purple-700 dark:text-purple-300",
+      icon: "text-purple-500 dark:text-purple-400",
+    },
+    blue: {
+      border: "border-blue-200 dark:border-blue-800",
+      bg: "bg-blue-50 dark:bg-blue-900/20",
+      text: "text-blue-700 dark:text-blue-300",
+      icon: "text-blue-500 dark:text-blue-400",
+    },
+  };
+
+  const colors = colorClasses[accentColor] || colorClasses.indigo;
+
+  return (
+    <div className={`border rounded-xl overflow-hidden ${colors.border}`}>
+      <div className={`p-4 ${colors.bg}`}>
+        <div className="flex items-start gap-3">
+          <div className={`mt-0.5 ${colors.icon}`}>{icon}</div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-2">
+              <h3 className={`text-sm font-bold uppercase tracking-wide ${colors.text}`}>
+                {title}
+              </h3>
+              {badge}
+            </div>
+            <div className="text-sm text-zinc-700 dark:text-zinc-300 leading-relaxed">
+              {children}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Explain accordion */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full px-4 py-2 flex items-center justify-between text-xs font-medium text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300 bg-white dark:bg-zinc-900 border-t border-zinc-100 dark:border-zinc-800 transition-colors"
+      >
+        <span>Explain</span>
+        <ChevronIcon expanded={expanded} />
+      </button>
+
+      {expanded && (
+        <div className="px-4 py-3 bg-white dark:bg-zinc-900 border-t border-zinc-100 dark:border-zinc-800">
+          <ul className="space-y-1.5">
+            {explainItems.map((item, i) => (
+              <li key={i} className="text-xs text-zinc-600 dark:text-zinc-400 flex items-start gap-2">
+                <span className="text-zinc-400 mt-0.5">-</span>
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================
+// VERIFICATION CHECK ITEM
+// ============================================
+
+function VerificationCheckItem({
+  label,
+  status,
+  detail,
+}: {
+  label: string;
+  status: "yes" | "no" | "partial" | "unknown";
+  detail: string;
+}) {
+  const statusConfig = {
+    yes: { icon: "checkmark", color: "text-emerald-600 dark:text-emerald-400", bg: "bg-emerald-100 dark:bg-emerald-900/30" },
+    no: { icon: "x", color: "text-rose-600 dark:text-rose-400", bg: "bg-rose-100 dark:bg-rose-900/30" },
+    partial: { icon: "minus", color: "text-amber-600 dark:text-amber-400", bg: "bg-amber-100 dark:bg-amber-900/30" },
+    unknown: { icon: "?", color: "text-zinc-500 dark:text-zinc-400", bg: "bg-zinc-100 dark:bg-zinc-800" },
+  };
+
+  const config = statusConfig[status];
+
+  return (
+    <div className="flex items-start gap-3 py-2">
+      <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold ${config.bg} ${config.color}`}>
+        {status === "yes" && "!"}
+        {status === "no" && "X"}
+        {status === "partial" && "~"}
+        {status === "unknown" && "?"}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-zinc-800 dark:text-zinc-200">{label}</div>
+        <div className="text-xs text-zinc-500 dark:text-zinc-400">{detail}</div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================
+// HEAT VS EVIDENCE BAR
+// ============================================
+
+function HeatEvidenceBar({ heat, evidence }: { heat: number; evidence: number }) {
+  const delta = heat - evidence;
+  const warningActive = delta >= 25;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-4">
+        <div className="flex-1">
+          <div className="flex items-center justify-between text-xs mb-1">
+            <span className="font-medium text-rose-600 dark:text-rose-400">Heat</span>
+            <span className="font-bold">{heat}</span>
+          </div>
+          <div className="h-2 bg-zinc-200 dark:bg-zinc-700 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-rose-500 rounded-full transition-all"
+              style={{ width: `${heat}%` }}
+            />
+          </div>
+        </div>
+        <div className="flex-1">
+          <div className="flex items-center justify-between text-xs mb-1">
+            <span className="font-medium text-emerald-600 dark:text-emerald-400">Evidence</span>
+            <span className="font-bold">{evidence}</span>
+          </div>
+          <div className="h-2 bg-zinc-200 dark:bg-zinc-700 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-emerald-500 rounded-full transition-all"
+              style={{ width: `${evidence}%` }}
+            />
+          </div>
+        </div>
+      </div>
+      {warningActive && (
+        <div className="flex items-center gap-2 px-3 py-2 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
+          <span className="text-amber-600 dark:text-amber-400 text-sm font-bold">Heat &gt; Evidence</span>
+          <span className="text-xs text-amber-700 dark:text-amber-300">
+            Emotional intensity exceeds factual grounding by {delta} points
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================
+// MAIN COMPONENT
+// ============================================
+
+export function AsymmetricValuePanel({ data }: AsymmetricValuePanelProps) {
+  const {
+    forecast,
+    heat_vs_evidence,
+    verification_checks,
+    incentive_fingerprint,
+    narrative_template,
+    low_regret_action,
+  } = data;
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <div className="w-1 h-8 bg-gradient-to-b from-indigo-500 to-purple-500 rounded-full" />
+        <div>
+          <h2 className="text-lg font-bold text-zinc-900 dark:text-white">Asymmetric Value</h2>
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">
+            Forecast + verification + action in 10 seconds
+          </p>
+        </div>
+      </div>
+
+      {/* Block 1: Forecast */}
+      <Block
+        icon={<ForecastIcon />}
+        title="Forecast"
+        badge={
+          <span
+            className={`px-2 py-0.5 text-[10px] font-bold uppercase rounded-full ${
+              forecast.confidence === "high"
+                ? "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300"
+                : forecast.confidence === "medium"
+                ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
+                : "bg-zinc-100 text-zinc-600 dark:bg-zinc-800 dark:text-zinc-400"
+            }`}
+          >
+            {forecast.confidence} confidence
+          </span>
+        }
+        accentColor={forecast.type === "neutral" ? "emerald" : "indigo"}
+        explainItems={[
+          `Forecast type: ${forecast.type.replace(/_/g, " ")}`,
+          "Based on detected language patterns and emotional signals",
+          "Higher confidence = stronger pattern match in content structure",
+          forecast.type !== "neutral"
+            ? "This doesn't mean the content is false - it means the framing is optimized for reaction"
+            : "Low manipulation signals detected in this content",
+        ]}
+      >
+        <p className="font-medium">{forecast.text}</p>
+      </Block>
+
+      {/* Block 2: Heat vs Evidence */}
+      <Block
+        icon={<HeatIcon />}
+        title="Manipulation ROI"
+        badge={
+          heat_vs_evidence.warning_active ? (
+            <span className="px-2 py-0.5 text-[10px] font-bold uppercase rounded-full bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300">
+              {heat_vs_evidence.warning_label}
+            </span>
+          ) : null
+        }
+        accentColor={heat_vs_evidence.warning_active ? "amber" : "emerald"}
+        explainItems={[
+          `Heat score (${heat_vs_evidence.heat_score}): Measures emotional intensity, urgency, and arousal`,
+          `Evidence score (${heat_vs_evidence.evidence_score}): Measures factual grounding and substantive claims`,
+          `Delta: ${heat_vs_evidence.delta >= 0 ? "+" : ""}${heat_vs_evidence.delta} (Heat minus Evidence)`,
+          "Delta >= 25 triggers a warning - high emotion with low substance",
+          "This metric helps identify content designed to provoke rather than inform",
+        ]}
+      >
+        <HeatEvidenceBar heat={heat_vs_evidence.heat_score} evidence={heat_vs_evidence.evidence_score} />
+        <p className="mt-3 text-zinc-600 dark:text-zinc-400">{heat_vs_evidence.interpretation}</p>
+      </Block>
+
+      {/* Block 3: Verification Shortcut */}
+      <Block
+        icon={<VerifyIcon />}
+        title="Verification Shortcut"
+        accentColor="blue"
+        explainItems={[
+          "Three quick checks before engaging with or sharing content",
+          "Primary source = original document, video, or direct statement",
+          "Date context = when did this actually happen?",
+          "Counter-evidence = have you seen the other side?",
+          "Each check based on what's present (or missing) in the content",
+        ]}
+      >
+        <div className="divide-y divide-zinc-100 dark:divide-zinc-800 -my-1">
+          {verification_checks.map((check, i) => (
+            <VerificationCheckItem key={i} {...check} />
+          ))}
+        </div>
+      </Block>
+
+      {/* Block 4: Incentive Fingerprint */}
+      <Block
+        icon={<FingerprintIcon />}
+        title="Incentive Fingerprint"
+        accentColor="purple"
+        explainItems={[
+          `Primary drivers detected: ${incentive_fingerprint.primary_drivers.map((d) => d.replace(/_/g, " ")).join(", ") || "none"}`,
+          "Every viral content has an incentive structure - what does it want from you?",
+          "Who benefits when you engage? The original poster, a cause, an algorithm?",
+          "This isn't about intent - it's about structural optimization",
+          "Knowing the incentive helps you decide if you want to participate",
+        ]}
+      >
+        <p className="font-medium">{incentive_fingerprint.text}</p>
+        {incentive_fingerprint.beneficiary && (
+          <p className="mt-2 text-xs text-zinc-500 dark:text-zinc-400 italic">
+            When it works: {incentive_fingerprint.beneficiary}
+          </p>
+        )}
+      </Block>
+
+      {/* Block 5: Narrative Template (conditional) */}
+      {narrative_template && (
+        <Block
+          icon={<TemplateIcon />}
+          title="Narrative Template"
+          badge={
+            <span className="px-2 py-0.5 text-[10px] font-bold uppercase rounded-full bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300">
+              {Math.round(narrative_template.confidence * 100)}% match
+            </span>
+          }
+          accentColor="purple"
+          explainItems={[
+            `Template detected: ${narrative_template.name}`,
+            "Viral content often follows recognizable patterns or 'templates'",
+            "These templates have been refined over time to maximize engagement",
+            "Recognizing the template helps you see past the specific content",
+            "Templates aren't inherently bad - but awareness helps critical thinking",
+          ]}
+        >
+          <p>
+            <span className="font-bold capitalize">{narrative_template.name}</span>
+            {" - "}
+            {narrative_template.description}
+          </p>
+        </Block>
+      )}
+
+      {/* Block 6: Low-Regret Action */}
+      <Block
+        icon={<ActionIcon />}
+        title="Low-Regret Action"
+        badge={
+          <span
+            className={`px-2 py-0.5 text-[10px] font-bold uppercase rounded-full ${
+              low_regret_action.priority === "high"
+                ? "bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300"
+                : low_regret_action.priority === "medium"
+                ? "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
+                : "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+            }`}
+          >
+            {low_regret_action.priority} priority
+          </span>
+        }
+        accentColor={
+          low_regret_action.priority === "high"
+            ? "rose"
+            : low_regret_action.priority === "medium"
+            ? "amber"
+            : "emerald"
+        }
+        explainItems={[
+          "The single most useful thing to do before engaging",
+          "Based on what's missing or concerning in this content",
+          "Low-regret = unlikely to backfire regardless of whether content is true",
+          low_regret_action.reason,
+          "Taking this action costs little but can prevent embarrassment or harm",
+        ]}
+      >
+        <p className="text-base font-bold text-zinc-900 dark:text-white">
+          {low_regret_action.action}
+        </p>
+        <p className="mt-1 text-zinc-600 dark:text-zinc-400">{low_regret_action.reason}</p>
+      </Block>
+    </div>
+  );
+}
+
+export default AsymmetricValuePanel;

--- a/src/components/SharecardSelector.tsx
+++ b/src/components/SharecardSelector.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { SharecardOutput, SharecardVariant } from "@/lib/asymmetricValue/types";
+import {
+  renderSharecardToCanvas,
+  copySharecardToClipboard,
+  downloadSharecard,
+  getSharecardText,
+  VARIANT_INFO,
+  getRecommendedVariant,
+} from "@/lib/asymmetricValue/SharecardRenderer";
+
+interface SharecardSelectorProps {
+  sharecards: SharecardOutput;
+  resultUrl: string;
+}
+
+export function SharecardSelector({ sharecards, resultUrl }: SharecardSelectorProps) {
+  const [selectedVariant, setSelectedVariant] = useState<SharecardVariant>(() =>
+    getRecommendedVariant(
+      parseInt(sharecards.respectful_share.heat_display),
+      parseInt(sharecards.respectful_share.evidence_display)
+    )
+  );
+  const [copied, setCopied] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const selectedContent = sharecards[selectedVariant];
+
+  // Render preview whenever selection changes
+  useEffect(() => {
+    if (canvasRef.current && selectedContent) {
+      renderSharecardToCanvas(canvasRef.current, {
+        variant: selectedVariant,
+        content: selectedContent,
+      });
+    }
+  }, [selectedVariant, selectedContent]);
+
+  const handleCopy = async () => {
+    const success = await copySharecardToClipboard({
+      variant: selectedVariant,
+      content: selectedContent,
+    });
+    if (success) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const handleDownload = async () => {
+    setDownloading(true);
+    await downloadSharecard(
+      { variant: selectedVariant, content: selectedContent },
+      `ragecheck-${selectedVariant}.png`
+    );
+    setDownloading(false);
+  };
+
+  const handleShareTwitter = () => {
+    const { twitterText } = getSharecardText(selectedContent, resultUrl);
+    const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(twitterText)}`;
+    window.open(url, "_blank");
+  };
+
+  const handleShareBluesky = () => {
+    const { blueskyText } = getSharecardText(selectedContent, resultUrl);
+    const url = `https://bsky.app/intent/compose?text=${encodeURIComponent(blueskyText)}`;
+    window.open(url, "_blank");
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-bold text-zinc-900 dark:text-white">Share Card</h3>
+        <span className="text-xs text-zinc-500">1200x630 for social</span>
+      </div>
+
+      {/* Variant selector */}
+      <div className="flex gap-2">
+        {VARIANT_INFO.map((info) => (
+          <button
+            key={info.id}
+            onClick={() => setSelectedVariant(info.id)}
+            className={`flex-1 px-3 py-2 rounded-lg text-left transition-all ${
+              selectedVariant === info.id
+                ? "bg-indigo-100 dark:bg-indigo-900/30 border-2 border-indigo-500"
+                : "bg-zinc-100 dark:bg-zinc-800 border-2 border-transparent hover:border-zinc-300 dark:hover:border-zinc-600"
+            }`}
+          >
+            <div className="text-xs font-bold text-zinc-900 dark:text-white">{info.name}</div>
+            <div className="text-[10px] text-zinc-500 dark:text-zinc-400">{info.tone}</div>
+          </button>
+        ))}
+      </div>
+
+      {/* Canvas preview */}
+      <div className="relative rounded-xl overflow-hidden border border-zinc-200 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800">
+        <canvas
+          ref={canvasRef}
+          className="w-full"
+          style={{ aspectRatio: "1200/630" }}
+        />
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-2">
+        <button
+          onClick={handleCopy}
+          className={`flex-1 px-4 py-3 rounded-lg font-medium text-sm transition-all flex items-center justify-center gap-2 ${
+            copied
+              ? "bg-emerald-500 text-white"
+              : "bg-zinc-900 dark:bg-white text-white dark:text-zinc-900 hover:opacity-90"
+          }`}
+        >
+          {copied ? (
+            <>
+              <CheckIcon />
+              Copied!
+            </>
+          ) : (
+            <>
+              <CopyIcon />
+              Copy Image
+            </>
+          )}
+        </button>
+
+        <button
+          onClick={handleDownload}
+          disabled={downloading}
+          className="px-4 py-3 rounded-lg font-medium text-sm bg-zinc-200 dark:bg-zinc-700 text-zinc-900 dark:text-white hover:bg-zinc-300 dark:hover:bg-zinc-600 transition-colors flex items-center gap-2"
+        >
+          <DownloadIcon />
+          {downloading ? "..." : "Save"}
+        </button>
+      </div>
+
+      {/* Share links */}
+      <div className="flex gap-2">
+        <button
+          onClick={handleShareTwitter}
+          className="flex-1 px-3 py-2 rounded-lg text-sm font-medium bg-black text-white hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+        >
+          <XIcon />
+          Share to X
+        </button>
+        <button
+          onClick={handleShareBluesky}
+          className="flex-1 px-3 py-2 rounded-lg text-sm font-medium bg-blue-500 text-white hover:opacity-90 transition-opacity flex items-center justify-center gap-2"
+        >
+          <BlueskyIcon />
+          Share to Bluesky
+        </button>
+      </div>
+
+      {/* Text preview */}
+      <details className="text-xs">
+        <summary className="cursor-pointer text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300">
+          View share text
+        </summary>
+        <div className="mt-2 p-3 bg-zinc-100 dark:bg-zinc-800 rounded-lg font-mono text-zinc-600 dark:text-zinc-400 whitespace-pre-wrap">
+          {getSharecardText(selectedContent, resultUrl).fullText}
+        </div>
+      </details>
+    </div>
+  );
+}
+
+// Icons
+function CopyIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+    </svg>
+  );
+}
+
+function DownloadIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+    </svg>
+  );
+}
+
+function XIcon() {
+  return (
+    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  );
+}
+
+function BlueskyIcon() {
+  return (
+    <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm5.5 14.5c-1.5 1.5-4 1.5-5.5 0-1.5-1.5-1.5-4 0-5.5 1.5-1.5 4-1.5 5.5 0 1.5 1.5 1.5 4 0 5.5z" />
+    </svg>
+  );
+}
+
+export default SharecardSelector;

--- a/src/lib/asymmetricValue/SharecardRenderer.ts
+++ b/src/lib/asymmetricValue/SharecardRenderer.ts
@@ -1,0 +1,361 @@
+/**
+ * Sharecard Renderer
+ *
+ * Generates shareable image cards with 3 style variants:
+ * 1. Respectful Share - Neutral, informative tone
+ * 2. Group Sanity Check - Collaborative, "let's verify together"
+ * 3. Direct Warning - Clear alert, still not insulting
+ *
+ * Target: 1200x630 (OpenGraph standard)
+ * Max text: 240 characters visible
+ */
+
+import { SharecardContent, SharecardOutput, SharecardVariant } from "./types";
+
+// ============================================
+// CONSTANTS
+// ============================================
+
+const CARD_WIDTH = 1200;
+const CARD_HEIGHT = 630;
+const SAFE_MARGIN = 60;
+
+const COLORS = {
+  // Backgrounds by variant
+  bg: {
+    respectful_share: "#F8FAFC", // Slate 50
+    group_sanity_check: "#FEF3C7", // Amber 100
+    direct_warning: "#FEE2E2", // Rose 100
+  },
+  // Accent colors
+  accent: {
+    respectful_share: "#6366F1", // Indigo 500
+    group_sanity_check: "#F59E0B", // Amber 500
+    direct_warning: "#EF4444", // Rose 500
+  },
+  // Text
+  text: {
+    primary: "#18181B", // Zinc 900
+    secondary: "#71717A", // Zinc 500
+    muted: "#A1A1AA", // Zinc 400
+  },
+  // Bars
+  heat: "#F43F5E", // Rose 500
+  evidence: "#10B981", // Emerald 500
+  barBg: "#E4E4E7", // Zinc 200
+};
+
+// ============================================
+// CANVAS RENDERING
+// ============================================
+
+export interface SharecardRenderOptions {
+  variant: SharecardVariant;
+  content: SharecardContent;
+}
+
+/**
+ * Render a sharecard to a canvas element
+ */
+export async function renderSharecardToCanvas(
+  canvas: HTMLCanvasElement,
+  options: SharecardRenderOptions
+): Promise<void> {
+  const { variant, content } = options;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Could not get canvas context");
+
+  canvas.width = CARD_WIDTH;
+  canvas.height = CARD_HEIGHT;
+
+  const bgColor = COLORS.bg[variant];
+  const accentColor = COLORS.accent[variant];
+
+  // Background
+  ctx.fillStyle = bgColor;
+  ctx.fillRect(0, 0, CARD_WIDTH, CARD_HEIGHT);
+
+  // Left accent bar
+  ctx.fillStyle = accentColor;
+  ctx.fillRect(0, 0, 8, CARD_HEIGHT);
+
+  // Hook line (main message)
+  ctx.fillStyle = COLORS.text.primary;
+  ctx.font = "bold 48px system-ui, -apple-system, sans-serif";
+  ctx.textBaseline = "top";
+  ctx.fillText(content.hook, SAFE_MARGIN, SAFE_MARGIN);
+
+  // Heat and Evidence bars
+  const barY = SAFE_MARGIN + 80;
+  const barWidth = 300;
+  const barHeight = 24;
+  const barGap = 16;
+
+  // Heat bar
+  ctx.fillStyle = COLORS.text.secondary;
+  ctx.font = "bold 14px system-ui, -apple-system, sans-serif";
+  ctx.fillText("HEAT", SAFE_MARGIN, barY);
+
+  ctx.fillStyle = COLORS.barBg;
+  ctx.fillRect(SAFE_MARGIN + 80, barY - 2, barWidth, barHeight);
+
+  const heatValue = parseInt(content.heat_display) || 0;
+  ctx.fillStyle = COLORS.heat;
+  ctx.fillRect(SAFE_MARGIN + 80, barY - 2, (barWidth * heatValue) / 100, barHeight);
+
+  ctx.fillStyle = COLORS.text.primary;
+  ctx.font = "bold 18px system-ui, -apple-system, sans-serif";
+  ctx.fillText(content.heat_display, SAFE_MARGIN + 80 + barWidth + 12, barY);
+
+  // Evidence bar
+  const evidenceY = barY + barHeight + barGap;
+  ctx.fillStyle = COLORS.text.secondary;
+  ctx.font = "bold 14px system-ui, -apple-system, sans-serif";
+  ctx.fillText("EVIDENCE", SAFE_MARGIN, evidenceY);
+
+  ctx.fillStyle = COLORS.barBg;
+  ctx.fillRect(SAFE_MARGIN + 80, evidenceY - 2, barWidth, barHeight);
+
+  const evidenceValue = parseInt(content.evidence_display) || 0;
+  ctx.fillStyle = COLORS.evidence;
+  ctx.fillRect(SAFE_MARGIN + 80, evidenceY - 2, (barWidth * evidenceValue) / 100, barHeight);
+
+  ctx.fillStyle = COLORS.text.primary;
+  ctx.font = "bold 18px system-ui, -apple-system, sans-serif";
+  ctx.fillText(content.evidence_display, SAFE_MARGIN + 80 + barWidth + 12, evidenceY);
+
+  // Verification flag (right side, pill style)
+  const flagY = barY + 10;
+  const flagX = CARD_WIDTH - SAFE_MARGIN - 280;
+
+  ctx.fillStyle = accentColor + "20"; // 20% opacity
+  roundRect(ctx, flagX, flagY, 280, 56, 12);
+  ctx.fill();
+
+  ctx.strokeStyle = accentColor;
+  ctx.lineWidth = 2;
+  roundRect(ctx, flagX, flagY, 280, 56, 12);
+  ctx.stroke();
+
+  ctx.fillStyle = accentColor;
+  ctx.font = "bold 11px system-ui, -apple-system, sans-serif";
+  ctx.fillText("VERIFICATION FLAG", flagX + 16, flagY + 18);
+
+  ctx.fillStyle = COLORS.text.primary;
+  ctx.font = "600 16px system-ui, -apple-system, sans-serif";
+  ctx.fillText(content.verification_flag, flagX + 16, flagY + 38);
+
+  // Divider line
+  const dividerY = CARD_HEIGHT - 180;
+  ctx.strokeStyle = COLORS.text.muted + "40";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(SAFE_MARGIN, dividerY);
+  ctx.lineTo(CARD_WIDTH - SAFE_MARGIN, dividerY);
+  ctx.stroke();
+
+  // Low-regret action box
+  const actionY = dividerY + 24;
+  ctx.fillStyle = COLORS.text.secondary;
+  ctx.font = "bold 12px system-ui, -apple-system, sans-serif";
+  ctx.fillText("BEFORE YOU ENGAGE", SAFE_MARGIN, actionY);
+
+  ctx.fillStyle = COLORS.text.primary;
+  ctx.font = "bold 28px system-ui, -apple-system, sans-serif";
+  ctx.fillText(content.low_regret_action, SAFE_MARGIN, actionY + 28);
+
+  // Footer
+  const footerY = CARD_HEIGHT - SAFE_MARGIN - 20;
+
+  // RageCheck logo placeholder (circle)
+  ctx.fillStyle = accentColor;
+  ctx.beginPath();
+  ctx.arc(SAFE_MARGIN + 16, footerY + 8, 16, 0, Math.PI * 2);
+  ctx.fill();
+
+  ctx.fillStyle = "#FFFFFF";
+  ctx.font = "bold 14px system-ui, -apple-system, sans-serif";
+  ctx.textAlign = "center";
+  ctx.fillText("R", SAFE_MARGIN + 16, footerY + 13);
+  ctx.textAlign = "left";
+
+  // Footer text
+  ctx.fillStyle = COLORS.text.secondary;
+  ctx.font = "600 16px system-ui, -apple-system, sans-serif";
+  ctx.fillText(content.footer_domain, SAFE_MARGIN + 44, footerY + 12);
+
+  // Source domain (right side)
+  ctx.textAlign = "right";
+  ctx.fillStyle = COLORS.text.muted;
+  ctx.font = "500 14px system-ui, -apple-system, sans-serif";
+  ctx.fillText(`Source: ${content.footer_source}`, CARD_WIDTH - SAFE_MARGIN, footerY + 12);
+  ctx.textAlign = "left";
+}
+
+/**
+ * Helper: Draw rounded rectangle
+ */
+function roundRect(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number
+): void {
+  ctx.beginPath();
+  ctx.moveTo(x + radius, y);
+  ctx.lineTo(x + width - radius, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + radius);
+  ctx.lineTo(x + width, y + height - radius);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+  ctx.lineTo(x + radius, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - radius);
+  ctx.lineTo(x, y + radius);
+  ctx.quadraticCurveTo(x, y, x + radius, y);
+  ctx.closePath();
+}
+
+/**
+ * Generate sharecard as a Blob
+ */
+export async function generateSharecardBlob(
+  options: SharecardRenderOptions
+): Promise<Blob> {
+  // Create offscreen canvas
+  const canvas = document.createElement("canvas");
+  await renderSharecardToCanvas(canvas, options);
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error("Failed to create blob"));
+      },
+      "image/png",
+      1.0
+    );
+  });
+}
+
+/**
+ * Copy sharecard to clipboard
+ */
+export async function copySharecardToClipboard(
+  options: SharecardRenderOptions
+): Promise<boolean> {
+  try {
+    const blob = await generateSharecardBlob(options);
+    await navigator.clipboard.write([
+      new ClipboardItem({ "image/png": blob }),
+    ]);
+    return true;
+  } catch (error) {
+    console.error("Failed to copy sharecard:", error);
+    return false;
+  }
+}
+
+/**
+ * Download sharecard as PNG
+ */
+export async function downloadSharecard(
+  options: SharecardRenderOptions,
+  filename: string = "ragecheck-sharecard.png"
+): Promise<void> {
+  const blob = await generateSharecardBlob(options);
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  URL.revokeObjectURL(url);
+}
+
+// ============================================
+// TEXT-ONLY EXPORT (for platforms without image)
+// ============================================
+
+export interface SharecardTextExport {
+  variant: SharecardVariant;
+  fullText: string;
+  twitterText: string;
+  blueskyText: string;
+}
+
+export function getSharecardText(
+  content: SharecardContent,
+  resultUrl: string
+): SharecardTextExport {
+  const { variant, hook, verification_flag, low_regret_action, footer_source } = content;
+
+  // Full text version
+  const fullText = `${hook}\n\nHeat: ${content.heat_display} | Evidence: ${content.evidence_display}\nFlag: ${verification_flag}\nAction: ${low_regret_action}\n\n${resultUrl}`;
+
+  // Twitter version (shorter)
+  const twitterText = `${hook}\n\n${verification_flag}\n${resultUrl}`;
+
+  // Bluesky version
+  const blueskyText = `${hook}\n\nRageCheck on ${footer_source}:\n${resultUrl}`;
+
+  return {
+    variant,
+    fullText,
+    twitterText,
+    blueskyText,
+  };
+}
+
+// ============================================
+// VARIANT SELECTOR
+// ============================================
+
+export interface VariantInfo {
+  id: SharecardVariant;
+  name: string;
+  description: string;
+  tone: string;
+}
+
+export const VARIANT_INFO: VariantInfo[] = [
+  {
+    id: "respectful_share",
+    name: "Respectful Share",
+    description: "Neutral, informative tone",
+    tone: "I found this worth checking",
+  },
+  {
+    id: "group_sanity_check",
+    name: "Group Sanity Check",
+    description: "Collaborative verification",
+    tone: "Let's verify this together",
+  },
+  {
+    id: "direct_warning",
+    name: "Direct Warning",
+    description: "Clear alert, not insulting",
+    tone: "Heads up on this one",
+  },
+];
+
+/**
+ * Get recommended variant based on content
+ */
+export function getRecommendedVariant(
+  heat_score: number,
+  evidence_score: number
+): SharecardVariant {
+  const delta = heat_score - evidence_score;
+
+  if (delta >= 40) {
+    return "direct_warning";
+  }
+  if (delta >= 20) {
+    return "group_sanity_check";
+  }
+  return "respectful_share";
+}

--- a/src/lib/asymmetricValue/__tests__/logic.test.ts
+++ b/src/lib/asymmetricValue/__tests__/logic.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Unit Tests for Asymmetric Value Logic
+ *
+ * Test cases covering:
+ * 1. High heat / low evidence
+ * 2. Low heat / high evidence
+ * 3. Missing date context
+ * 4. Missing citations
+ * 5. Screenshot content type
+ * 6. Template match present/absent
+ * 7. High ambiguity
+ * 8. Non-English post text (safe rendering)
+ */
+
+import {
+  computeHeatVsEvidence,
+  computeForecast,
+  computeVerificationChecks,
+  computeIncentiveFingerprint,
+  computeNarrativeTemplate,
+  computeLowRegretAction,
+  computeAsymmetricValue,
+  generateSharecards,
+} from "../logic";
+import { AsymmetricValueInput, LanguageCategory } from "../types";
+
+// ============================================
+// TEST HELPERS
+// ============================================
+
+function createMockInput(overrides: Partial<AsymmetricValueInput> = {}): AsymmetricValueInput {
+  return {
+    content_type: "article",
+    original_url: "https://example.com/article",
+    post_text: "This is a test article about something important.",
+    extracted_claims: [],
+    citations_found: [],
+    has_date_context: true,
+    detected_date: new Date().toISOString(),
+    language_features: {
+      heat_score: 50,
+      evidence_score: 50,
+      agency_score: 30,
+      ambiguity_score: 20,
+      categories: [],
+    },
+    ...overrides,
+  };
+}
+
+// ============================================
+// TEST CASE 1: HIGH HEAT / LOW EVIDENCE
+// ============================================
+
+describe("High heat / low evidence", () => {
+  const input = createMockInput({
+    language_features: {
+      heat_score: 85,
+      evidence_score: 25,
+      agency_score: 60,
+      ambiguity_score: 40,
+      categories: ["fear_alert", "call_to_share"],
+    },
+  });
+
+  test("Heat vs Evidence shows warning", () => {
+    const result = computeHeatVsEvidence(85, 25);
+    expect(result.warning_active).toBe(true);
+    expect(result.warning_label).toBe("Heat > Evidence");
+    expect(result.delta).toBe(60);
+  });
+
+  test("Forecast predicts impulsive sharing", () => {
+    const result = computeForecast(["fear_alert", "call_to_share"], 85, 25);
+    expect(result.type).toBe("impulsive_sharing");
+    expect(result.confidence).toBe("high");
+  });
+
+  test("Low-regret action suggests waiting", () => {
+    const heatVsEvidence = computeHeatVsEvidence(85, 25);
+    const verificationChecks = computeVerificationChecks(input);
+    const result = computeLowRegretAction(input, heatVsEvidence, verificationChecks);
+    expect(result.action).toContain("Wait");
+  });
+});
+
+// ============================================
+// TEST CASE 2: LOW HEAT / HIGH EVIDENCE
+// ============================================
+
+describe("Low heat / high evidence", () => {
+  const input = createMockInput({
+    language_features: {
+      heat_score: 20,
+      evidence_score: 80,
+      agency_score: 10,
+      ambiguity_score: 10,
+      categories: [],
+    },
+    citations_found: [{ url: "https://primary.gov/doc", domain: "primary.gov", type: "primary" }],
+  });
+
+  test("Heat vs Evidence shows no warning", () => {
+    const result = computeHeatVsEvidence(20, 80);
+    expect(result.warning_active).toBe(false);
+    expect(result.warning_label).toBeUndefined();
+    expect(result.delta).toBe(-60);
+  });
+
+  test("Forecast is neutral", () => {
+    const result = computeForecast([], 20, 80);
+    expect(result.type).toBe("neutral");
+  });
+
+  test("Incentive fingerprint shows informational", () => {
+    const result = computeIncentiveFingerprint([], 20);
+    expect(result.action).toBe("inform without manipulation");
+  });
+});
+
+// ============================================
+// TEST CASE 3: MISSING DATE CONTEXT
+// ============================================
+
+describe("Missing date context", () => {
+  const input = createMockInput({
+    has_date_context: false,
+    detected_date: undefined,
+    citations_found: [{ url: "https://source.com", domain: "source.com", type: "primary" }],
+  });
+
+  test("Verification check shows no date", () => {
+    const result = computeVerificationChecks(input);
+    const dateCheck = result[1];
+    expect(dateCheck.status).toBe("no");
+    expect(dateCheck.label).toBe("Date context present?");
+  });
+
+  test("Low-regret action suggests checking date", () => {
+    const heatVsEvidence = computeHeatVsEvidence(50, 50);
+    const verificationChecks = computeVerificationChecks(input);
+    const result = computeLowRegretAction(input, heatVsEvidence, verificationChecks);
+    expect(result.action.toLowerCase()).toContain("date");
+  });
+});
+
+// ============================================
+// TEST CASE 4: MISSING CITATIONS
+// ============================================
+
+describe("Missing citations", () => {
+  const input = createMockInput({
+    citations_found: [],
+    content_type: "tweet",
+  });
+
+  test("Verification check shows no primary source", () => {
+    const result = computeVerificationChecks(input);
+    const primaryCheck = result[0];
+    expect(primaryCheck.status).toBe("no");
+    expect(primaryCheck.detail).toContain("No sources");
+  });
+
+  test("Low-regret action suggests asking for source", () => {
+    const heatVsEvidence = computeHeatVsEvidence(50, 50);
+    const verificationChecks = computeVerificationChecks(input);
+    const result = computeLowRegretAction(input, heatVsEvidence, verificationChecks);
+    expect(result.action.toLowerCase()).toContain("source");
+  });
+});
+
+// ============================================
+// TEST CASE 5: SCREENSHOT CONTENT TYPE
+// ============================================
+
+describe("Screenshot content type", () => {
+  const input = createMockInput({
+    content_type: "screenshot",
+    citations_found: [],
+  });
+
+  test("Verification check mentions screenshot risk", () => {
+    const result = computeVerificationChecks(input);
+    const primaryCheck = result[0];
+    expect(primaryCheck.detail.toLowerCase()).toContain("screenshot");
+  });
+
+  test("Low-regret action suggests reverse image search", () => {
+    const heatVsEvidence = computeHeatVsEvidence(50, 50);
+    const verificationChecks = computeVerificationChecks(input);
+    const result = computeLowRegretAction(input, heatVsEvidence, verificationChecks);
+    expect(result.action.toLowerCase()).toContain("reverse");
+  });
+
+  test("Sharecard includes screenshot flag", () => {
+    const output = computeAsymmetricValue(input);
+    const sharecards = generateSharecards(
+      output.forecast,
+      output.heat_vs_evidence,
+      output.verification_checks,
+      output.low_regret_action,
+      input.original_url,
+      input.content_type
+    );
+    expect(sharecards.respectful_share.verification_flag).toBe("Screenshot risk");
+  });
+});
+
+// ============================================
+// TEST CASE 6: TEMPLATE MATCH PRESENT/ABSENT
+// ============================================
+
+describe("Template match", () => {
+  test("Returns template when confidence >= 0.65", () => {
+    const result = computeNarrativeTemplate({
+      template_name: "outrage_bait",
+      confidence: 0.72,
+    });
+    expect(result).toBeDefined();
+    expect(result?.name).toBe("outrage bait");
+    expect(result?.confidence).toBe(0.72);
+  });
+
+  test("Returns undefined when confidence < 0.65", () => {
+    const result = computeNarrativeTemplate({
+      template_name: "outrage_bait",
+      confidence: 0.5,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  test("Returns undefined when no template provided", () => {
+    const result = computeNarrativeTemplate(undefined);
+    expect(result).toBeUndefined();
+  });
+});
+
+// ============================================
+// TEST CASE 7: HIGH AMBIGUITY
+// ============================================
+
+describe("High ambiguity", () => {
+  const input = createMockInput({
+    language_features: {
+      heat_score: 40,
+      evidence_score: 30,
+      agency_score: 20,
+      ambiguity_score: 75,
+      categories: [],
+    },
+    citations_found: [{ url: "https://source.com", domain: "source.com", type: "secondary" }],
+  });
+
+  test("Verification check suggests counter-evidence", () => {
+    const result = computeVerificationChecks(input);
+    const counterCheck = result[2];
+    expect(counterCheck.status).toBe("no");
+    expect(counterCheck.detail.toLowerCase()).toContain("ambiguity");
+  });
+});
+
+// ============================================
+// TEST CASE 8: NON-ENGLISH POST TEXT
+// ============================================
+
+describe("Non-English post text (safe rendering)", () => {
+  const input = createMockInput({
+    post_text: "これは日本語のテストです。重要なニュースについて。", // Japanese
+    language_features: {
+      heat_score: 50,
+      evidence_score: 50,
+      agency_score: 30,
+      ambiguity_score: 20,
+      categories: [],
+    },
+  });
+
+  test("Computes without throwing", () => {
+    expect(() => computeAsymmetricValue(input)).not.toThrow();
+  });
+
+  test("Returns valid output structure", () => {
+    const result = computeAsymmetricValue(input);
+    expect(result.forecast).toBeDefined();
+    expect(result.heat_vs_evidence).toBeDefined();
+    expect(result.verification_checks).toHaveLength(3);
+    expect(result.low_regret_action).toBeDefined();
+  });
+
+  test("Sharecards render safely", () => {
+    const output = computeAsymmetricValue(input);
+    const sharecards = generateSharecards(
+      output.forecast,
+      output.heat_vs_evidence,
+      output.verification_checks,
+      output.low_regret_action,
+      input.original_url,
+      input.content_type
+    );
+    expect(sharecards.respectful_share.hook).toBeDefined();
+    expect(sharecards.group_sanity_check.hook).toBeDefined();
+    expect(sharecards.direct_warning.hook).toBeDefined();
+  });
+});
+
+// ============================================
+// ADDITIONAL EDGE CASES
+// ============================================
+
+describe("Edge cases", () => {
+  test("Empty categories array", () => {
+    const result = computeForecast([], 50, 50);
+    expect(result.type).toBe("neutral");
+  });
+
+  test("All categories present", () => {
+    const allCategories: LanguageCategory[] = [
+      "enemy_construction",
+      "betrayal_narrative",
+      "fear_alert",
+      "moral_purity_test",
+      "humiliation",
+      "status_signal",
+      "conspiracy_frame",
+      "doom_loop",
+      "call_to_punish",
+      "call_to_share",
+    ];
+    const result = computeForecast(allCategories, 90, 10);
+    expect(result.type).not.toBe("neutral");
+  });
+
+  test("Zero scores", () => {
+    const result = computeHeatVsEvidence(0, 0);
+    expect(result.delta).toBe(0);
+    expect(result.warning_active).toBe(false);
+  });
+
+  test("Maximum scores", () => {
+    const result = computeHeatVsEvidence(100, 100);
+    expect(result.delta).toBe(0);
+    expect(result.warning_active).toBe(false);
+  });
+
+  test("Old date triggers partial status", () => {
+    const twoYearsAgo = new Date();
+    twoYearsAgo.setFullYear(twoYearsAgo.getFullYear() - 2);
+
+    const input = createMockInput({
+      has_date_context: true,
+      detected_date: twoYearsAgo.toISOString(),
+    });
+
+    const result = computeVerificationChecks(input);
+    const dateCheck = result[1];
+    expect(dateCheck.status).toBe("partial");
+    expect(dateCheck.detail.toLowerCase()).toContain("year");
+  });
+});
+
+// ============================================
+// INTEGRATION TEST
+// ============================================
+
+describe("Full computation flow", () => {
+  test("computeAsymmetricValue returns complete output", () => {
+    const input = createMockInput({
+      language_features: {
+        heat_score: 70,
+        evidence_score: 30,
+        agency_score: 50,
+        ambiguity_score: 30,
+        categories: ["enemy_construction", "moral_purity_test"],
+      },
+      template_match: {
+        template_name: "tribal_signaling",
+        confidence: 0.8,
+      },
+    });
+
+    const result = computeAsymmetricValue(input);
+
+    // Verify all fields present
+    expect(result.forecast).toBeDefined();
+    expect(result.heat_vs_evidence).toBeDefined();
+    expect(result.verification_checks).toHaveLength(3);
+    expect(result.incentive_fingerprint).toBeDefined();
+    expect(result.narrative_template).toBeDefined(); // Should be present with 0.8 confidence
+    expect(result.low_regret_action).toBeDefined();
+    expect(result.computed_at).toBeDefined();
+    expect(result.input_hash).toBeDefined();
+
+    // Verify heat vs evidence warning is active
+    expect(result.heat_vs_evidence.warning_active).toBe(true);
+
+    // Verify forecast type
+    expect(result.forecast.type).toBe("polarization");
+  });
+});

--- a/src/lib/asymmetricValue/adapter.ts
+++ b/src/lib/asymmetricValue/adapter.ts
@@ -1,0 +1,301 @@
+/**
+ * Adapter: Maps existing RageCheck analysis to AsymmetricValue input
+ *
+ * This bridges the current analysis output to the new Asymmetric Value system.
+ */
+
+import {
+  AsymmetricValueInput,
+  ContentType,
+  LanguageCategory,
+  LanguageFeatures,
+  Citation,
+  ExtractedClaim,
+} from "./types";
+
+interface SignalBreakdown {
+  arousal: number;
+  enemy_construction: number;
+  moral_condemnation: number;
+  simplification: number;
+  call_to_conflict: number;
+}
+
+interface Highlight {
+  text: string;
+  category: string;
+}
+
+interface AnalysisResult {
+  score?: number;
+  signalBreakdown?: SignalBreakdown;
+  title?: string;
+  sourceDomain?: string;
+  textPreview?: string;
+  highlights?: Highlight[];
+  reasons?: string[];
+  techniqueExplanations?: string[];
+  sharingPatterns?: string[];
+}
+
+/**
+ * Detect content type from URL or domain
+ */
+function detectContentType(url: string, domain?: string): ContentType {
+  const lowerUrl = url.toLowerCase();
+  const lowerDomain = (domain || "").toLowerCase();
+
+  if (
+    lowerUrl.includes("twitter.com") ||
+    lowerUrl.includes("x.com") ||
+    lowerDomain.includes("twitter") ||
+    lowerDomain.includes("x.com")
+  ) {
+    return "tweet";
+  }
+
+  if (lowerUrl.includes("bsky.app") || lowerDomain.includes("bsky")) {
+    return "bluesky_post";
+  }
+
+  if (url.startsWith("data:image") || url.includes("blob:")) {
+    return "screenshot";
+  }
+
+  return "article";
+}
+
+/**
+ * Map signal breakdown categories to language categories
+ */
+function mapCategories(
+  signalBreakdown: SignalBreakdown,
+  highlights?: Highlight[]
+): LanguageCategory[] {
+  const categories: LanguageCategory[] = [];
+
+  // Map from 5-bar model to language categories
+  if (signalBreakdown.enemy_construction >= 40) {
+    categories.push("enemy_construction");
+  }
+
+  if (signalBreakdown.moral_condemnation >= 40) {
+    categories.push("moral_purity_test");
+  }
+
+  if (signalBreakdown.call_to_conflict >= 40) {
+    categories.push("call_to_punish");
+  }
+
+  if (signalBreakdown.arousal >= 60) {
+    categories.push("fear_alert");
+  }
+
+  // Infer additional categories from highlights
+  if (highlights) {
+    const highlightTexts = highlights.map((h) => h.text.toLowerCase()).join(" ");
+
+    if (
+      highlightTexts.includes("share") ||
+      highlightTexts.includes("retweet") ||
+      highlightTexts.includes("spread")
+    ) {
+      categories.push("call_to_share");
+    }
+
+    if (
+      highlightTexts.includes("betray") ||
+      highlightTexts.includes("sold out") ||
+      highlightTexts.includes("backstab")
+    ) {
+      categories.push("betrayal_narrative");
+    }
+
+    if (
+      highlightTexts.includes("doom") ||
+      highlightTexts.includes("collapse") ||
+      highlightTexts.includes("end of")
+    ) {
+      categories.push("doom_loop");
+    }
+
+    if (
+      highlightTexts.includes("humiliat") ||
+      highlightTexts.includes("embarrass") ||
+      highlightTexts.includes("own") ||
+      highlightTexts.includes("ratio")
+    ) {
+      categories.push("humiliation");
+    }
+  }
+
+  // Deduplicate
+  return [...new Set(categories)];
+}
+
+/**
+ * Compute language features from signal breakdown
+ */
+function computeLanguageFeatures(
+  signalBreakdown: SignalBreakdown,
+  highlights?: Highlight[],
+  textPreview?: string
+): LanguageFeatures {
+  // Heat score: weighted combination of emotional signals
+  const heat_score = Math.round(
+    signalBreakdown.arousal * 0.35 +
+      signalBreakdown.enemy_construction * 0.25 +
+      signalBreakdown.moral_condemnation * 0.25 +
+      signalBreakdown.call_to_conflict * 0.15
+  );
+
+  // Evidence score: inverse of simplification + base from low arousal
+  // Higher simplification = lower evidence
+  const evidence_score = Math.round(
+    Math.max(0, 100 - signalBreakdown.simplification * 0.7 - signalBreakdown.arousal * 0.3)
+  );
+
+  // Agency score: how much it calls for action
+  const agency_score = Math.round(
+    signalBreakdown.call_to_conflict * 0.6 +
+      signalBreakdown.moral_condemnation * 0.4
+  );
+
+  // Ambiguity score: based on simplification and lack of specifics
+  const ambiguity_score = Math.round(signalBreakdown.simplification * 0.8);
+
+  const categories = mapCategories(signalBreakdown, highlights);
+
+  return {
+    heat_score: Math.min(100, Math.max(0, heat_score)),
+    evidence_score: Math.min(100, Math.max(0, evidence_score)),
+    agency_score: Math.min(100, Math.max(0, agency_score)),
+    ambiguity_score: Math.min(100, Math.max(0, ambiguity_score)),
+    categories,
+  };
+}
+
+/**
+ * Extract claims from text and highlights
+ */
+function extractClaims(
+  textPreview?: string,
+  highlights?: Highlight[]
+): ExtractedClaim[] {
+  const claims: ExtractedClaim[] = [];
+
+  // Use highlights as proxy for claims
+  if (highlights) {
+    highlights.slice(0, 5).forEach((h) => {
+      claims.push({ claim_text: h.text });
+    });
+  }
+
+  return claims;
+}
+
+/**
+ * Detect if content has date context
+ */
+function detectDateContext(textPreview?: string): {
+  has_date: boolean;
+  detected_date?: string;
+} {
+  if (!textPreview) {
+    return { has_date: false };
+  }
+
+  // Simple date patterns
+  const datePatterns = [
+    /\b(january|february|march|april|may|june|july|august|september|october|november|december)\s+\d{1,2},?\s+\d{4}/i,
+    /\b\d{1,2}\/\d{1,2}\/\d{2,4}\b/,
+    /\b\d{4}-\d{2}-\d{2}\b/,
+    /\b(today|yesterday|last week|this week|last month)\b/i,
+    /\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/i,
+  ];
+
+  for (const pattern of datePatterns) {
+    const match = textPreview.match(pattern);
+    if (match) {
+      return {
+        has_date: true,
+        detected_date: new Date().toISOString(), // Simplified: just mark as detected
+      };
+    }
+  }
+
+  return { has_date: false };
+}
+
+/**
+ * Main adapter function
+ */
+export function adaptAnalysisToInput(
+  url: string,
+  analysis: AnalysisResult
+): AsymmetricValueInput {
+  const signalBreakdown = analysis.signalBreakdown || {
+    arousal: 0,
+    enemy_construction: 0,
+    moral_condemnation: 0,
+    simplification: 0,
+    call_to_conflict: 0,
+  };
+
+  const languageFeatures = computeLanguageFeatures(
+    signalBreakdown,
+    analysis.highlights,
+    analysis.textPreview
+  );
+
+  const dateContext = detectDateContext(analysis.textPreview);
+
+  const extractedClaims = extractClaims(
+    analysis.textPreview,
+    analysis.highlights
+  );
+
+  // For now, we don't have citation extraction - mark as empty
+  const citations: Citation[] = [];
+
+  return {
+    content_type: detectContentType(url, analysis.sourceDomain),
+    original_url: url,
+    post_text: analysis.textPreview || analysis.title || "",
+    extracted_claims: extractedClaims,
+    citations_found: citations,
+    has_date_context: dateContext.has_date,
+    detected_date: dateContext.detected_date,
+    language_features: languageFeatures,
+    // Template matching would require additional analysis
+    template_match: undefined,
+    user_context: undefined,
+  };
+}
+
+/**
+ * Quick validation for input
+ */
+export function validateInput(input: AsymmetricValueInput): {
+  valid: boolean;
+  errors: string[];
+} {
+  const errors: string[] = [];
+
+  if (!input.original_url) {
+    errors.push("Missing original_url");
+  }
+
+  if (!input.post_text && input.content_type !== "screenshot") {
+    errors.push("Missing post_text");
+  }
+
+  if (!input.language_features) {
+    errors.push("Missing language_features");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}

--- a/src/lib/asymmetricValue/index.ts
+++ b/src/lib/asymmetricValue/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Asymmetric Value Module
+ *
+ * Exports all types and functions for the Asymmetric Value feature.
+ */
+
+export * from "./types";
+export * from "./logic";
+export { computeAsymmetricValue, generateSharecards, toJSON } from "./logic";
+export { adaptAnalysisToInput, validateInput } from "./adapter";
+export {
+  renderSharecardToCanvas,
+  generateSharecardBlob,
+  copySharecardToClipboard,
+  downloadSharecard,
+  getSharecardText,
+  VARIANT_INFO,
+  getRecommendedVariant,
+} from "./SharecardRenderer";

--- a/src/lib/asymmetricValue/logic.ts
+++ b/src/lib/asymmetricValue/logic.ts
@@ -1,0 +1,681 @@
+/**
+ * Asymmetric Value Logic Module
+ *
+ * Core decision logic for computing forecasts, verification shortcuts,
+ * incentive fingerprints, and low-regret actions.
+ */
+
+import {
+  AsymmetricValueInput,
+  AsymmetricValueOutput,
+  AsymmetricValueJSON,
+  Forecast,
+  ForecastType,
+  HeatVsEvidence,
+  VerificationCheck,
+  VerificationStatus,
+  IncentiveFingerprint,
+  IncentiveAction,
+  LanguageCategory,
+  NarrativeTemplate,
+  LowRegretAction,
+  SharecardOutput,
+  SharecardContent,
+  SharecardVariant,
+} from "./types";
+
+// ============================================
+// HEAT VS EVIDENCE
+// ============================================
+
+export function computeHeatVsEvidence(
+  heat_score: number,
+  evidence_score: number
+): HeatVsEvidence {
+  const delta = heat_score - evidence_score;
+  const warning_active = delta >= 25;
+
+  let interpretation: string;
+  if (delta >= 40) {
+    interpretation =
+      "High emotional intensity with minimal factual grounding. Classic manipulation signature.";
+  } else if (delta >= 25) {
+    interpretation =
+      "Emotional framing outpaces the evidence provided. Worth verifying before engaging.";
+  } else if (delta >= 10) {
+    interpretation =
+      "Moderate emotional content relative to evidence. Normal range for opinion pieces.";
+  } else if (delta >= -10) {
+    interpretation =
+      "Balanced emotional tone and evidence. Typical of substantive reporting.";
+  } else {
+    interpretation =
+      "Evidence-heavy with restrained emotional framing. Analytical or academic style.";
+  }
+
+  return {
+    heat_score,
+    evidence_score,
+    delta,
+    warning_active,
+    warning_label: warning_active ? "Heat > Evidence" : undefined,
+    interpretation,
+  };
+}
+
+// ============================================
+// FORECAST
+// ============================================
+
+const FORECAST_MAP: Record<ForecastType, string> = {
+  impulsive_sharing:
+    "Content structure optimizes for rapid sharing before verification. Expect quick spread with limited fact-checking.",
+  polarization:
+    "Framing emphasizes group identity and moral certainty. Likely to reinforce existing beliefs and widen divides.",
+  dunking_dynamics:
+    "Content sets up targets for public criticism. May trigger pile-on behavior and quote-tweet mockery.",
+  anxiety_spiral:
+    "Threat framing designed to activate fear responses. May lead to doom-scrolling or anxiety sharing.",
+  outgroup_distrust:
+    "Builds narrative of 'them vs us.' Optimized to deepen distrust of specific groups or institutions.",
+  neutral:
+    "No strong manipulation pattern detected. Standard informational content.",
+};
+
+export function computeForecast(
+  categories: LanguageCategory[],
+  heat_score: number,
+  evidence_score: number
+): Forecast {
+  const delta = heat_score - evidence_score;
+
+  // Priority-ordered checks
+  if (
+    categories.includes("call_to_share") ||
+    (categories.includes("fear_alert") && delta >= 20)
+  ) {
+    return {
+      type: "impulsive_sharing",
+      text: FORECAST_MAP.impulsive_sharing,
+      confidence: delta >= 30 ? "high" : "medium",
+    };
+  }
+
+  if (categories.includes("humiliation") || categories.includes("call_to_punish")) {
+    return {
+      type: "dunking_dynamics",
+      text: FORECAST_MAP.dunking_dynamics,
+      confidence: categories.includes("call_to_punish") ? "high" : "medium",
+    };
+  }
+
+  if (
+    categories.includes("enemy_construction") ||
+    categories.includes("moral_purity_test")
+  ) {
+    return {
+      type: "polarization",
+      text: FORECAST_MAP.polarization,
+      confidence:
+        categories.includes("enemy_construction") &&
+        categories.includes("moral_purity_test")
+          ? "high"
+          : "medium",
+    };
+  }
+
+  if (categories.includes("doom_loop") || categories.includes("fear_alert")) {
+    return {
+      type: "anxiety_spiral",
+      text: FORECAST_MAP.anxiety_spiral,
+      confidence: categories.includes("doom_loop") ? "high" : "medium",
+    };
+  }
+
+  if (categories.includes("betrayal_narrative") || categories.includes("conspiracy_frame")) {
+    return {
+      type: "outgroup_distrust",
+      text: FORECAST_MAP.outgroup_distrust,
+      confidence: categories.includes("conspiracy_frame") ? "high" : "medium",
+    };
+  }
+
+  return {
+    type: "neutral",
+    text: FORECAST_MAP.neutral,
+    confidence: "low",
+  };
+}
+
+// ============================================
+// VERIFICATION SHORTCUT
+// ============================================
+
+export function computeVerificationChecks(
+  input: AsymmetricValueInput
+): [VerificationCheck, VerificationCheck, VerificationCheck] {
+  const { citations_found, has_date_context, language_features, content_type } =
+    input;
+
+  // Check 1: Primary source present?
+  const primarySources = citations_found.filter((c) => c.type === "primary");
+  const hasPrimary = primarySources.length > 0;
+
+  let check1Status: VerificationStatus;
+  let check1Detail: string;
+
+  if (hasPrimary) {
+    check1Status = "yes";
+    check1Detail = `Primary source linked: ${primarySources[0].domain}`;
+  } else if (citations_found.length > 0) {
+    check1Status = "partial";
+    check1Detail = `${citations_found.length} secondary source(s), no primary`;
+  } else {
+    check1Status = "no";
+    check1Detail =
+      content_type === "screenshot"
+        ? "Screenshot with no verifiable source"
+        : "No sources linked in content";
+  }
+
+  const check1: VerificationCheck = {
+    label: "Primary source present?",
+    status: check1Status,
+    detail: check1Detail,
+  };
+
+  // Check 2: Date context present?
+  let check2Status: VerificationStatus;
+  let check2Detail: string;
+
+  if (has_date_context && input.detected_date) {
+    const dateObj = new Date(input.detected_date);
+    const now = new Date();
+    const daysDiff = Math.floor(
+      (now.getTime() - dateObj.getTime()) / (1000 * 60 * 60 * 24)
+    );
+
+    if (daysDiff > 365) {
+      check2Status = "partial";
+      check2Detail = `Dated ${Math.floor(daysDiff / 365)}+ years ago. May be resurfaced content.`;
+    } else if (daysDiff > 30) {
+      check2Status = "partial";
+      check2Detail = `Dated ${daysDiff} days ago. Check if still relevant.`;
+    } else {
+      check2Status = "yes";
+      check2Detail = `Recent: ${dateObj.toLocaleDateString()}`;
+    }
+  } else {
+    check2Status = "no";
+    check2Detail = "No clear date or timeframe provided";
+  }
+
+  const check2: VerificationCheck = {
+    label: "Date context present?",
+    status: check2Status,
+    detail: check2Detail,
+  };
+
+  // Check 3: Counter-evidence suggested?
+  const needsCounterEvidence =
+    language_features.evidence_score < 40 ||
+    language_features.ambiguity_score > 60;
+
+  let check3Status: VerificationStatus;
+  let check3Detail: string;
+
+  if (!needsCounterEvidence) {
+    check3Status = "yes";
+    check3Detail = "Evidence score adequate. Standard verification applies.";
+  } else if (language_features.ambiguity_score > 60) {
+    check3Status = "no";
+    check3Detail = "High ambiguity. Search for primary source to clarify claims.";
+  } else {
+    check3Status = "no";
+    check3Detail =
+      "Low evidence score. Search for reputable counter-perspectives.";
+  }
+
+  const check3: VerificationCheck = {
+    label: "Counter-evidence suggested?",
+    status: check3Status,
+    detail: check3Detail,
+  };
+
+  return [check1, check2, check3];
+}
+
+// ============================================
+// INCENTIVE FINGERPRINT
+// ============================================
+
+const CATEGORY_TO_ACTION: Record<LanguageCategory, IncentiveAction> = {
+  call_to_share: "make you share fast",
+  fear_alert: "make you feel threatened",
+  enemy_construction: "make you distrust an outgroup",
+  moral_purity_test: "make you feel morally certain",
+  humiliation: "make you join a pile-on",
+  call_to_punish: "make you punish/ban",
+  betrayal_narrative: "make you distrust an outgroup",
+  conspiracy_frame: "make you distrust an outgroup",
+  doom_loop: "make you feel threatened",
+  status_signal: "make you feel morally certain",
+};
+
+const ACTION_BENEFICIARIES: Record<IncentiveAction, string> = {
+  "make you share fast": "the original poster gains reach",
+  "make you distrust an outgroup": "in-group loyalty strengthens",
+  "make you feel morally certain": "engagement increases through validation",
+  "make you join a pile-on": "the poster gains status through target's humiliation",
+  "make you feel threatened": "attention economy captures your anxiety",
+  "make you punish/ban": "moderation pressure shifts platform dynamics",
+  "inform without manipulation": "no clear beneficiary beyond the reader",
+};
+
+export function computeIncentiveFingerprint(
+  categories: LanguageCategory[],
+  heat_score: number
+): IncentiveFingerprint {
+  if (categories.length === 0 || heat_score < 20) {
+    return {
+      primary_drivers: [],
+      action: "inform without manipulation",
+      beneficiary: ACTION_BENEFICIARIES["inform without manipulation"],
+      text: "This content appears informational without strong manipulation signals.",
+    };
+  }
+
+  // Get top 2 categories by manipulation severity
+  const categoryPriority: LanguageCategory[] = [
+    "call_to_punish",
+    "enemy_construction",
+    "humiliation",
+    "fear_alert",
+    "moral_purity_test",
+    "call_to_share",
+    "conspiracy_frame",
+    "betrayal_narrative",
+    "doom_loop",
+    "status_signal",
+  ];
+
+  const sortedCategories = categories.sort(
+    (a, b) => categoryPriority.indexOf(a) - categoryPriority.indexOf(b)
+  );
+
+  const primaryDrivers = sortedCategories.slice(0, 2);
+  const primaryCategory = primaryDrivers[0];
+  const action = CATEGORY_TO_ACTION[primaryCategory];
+  const beneficiary = ACTION_BENEFICIARIES[action];
+
+  const driverLabels = primaryDrivers
+    .map((c) => c.replace(/_/g, " "))
+    .join(" + ");
+
+  return {
+    primary_drivers: primaryDrivers,
+    action,
+    beneficiary,
+    text: `This is optimized to: ${action}. Primary drivers: ${driverLabels}. When it works, ${beneficiary}.`,
+  };
+}
+
+// ============================================
+// NARRATIVE TEMPLATE
+// ============================================
+
+const TEMPLATE_DESCRIPTIONS: Record<string, string> = {
+  outrage_bait:
+    "Content structured to maximize emotional reaction and sharing impulse.",
+  tribal_signaling:
+    "Designed to reinforce in-group identity and signal membership.",
+  fear_cascade:
+    "Uses escalating threat framing to maintain attention and anxiety.",
+  righteous_dunking:
+    "Sets up target for public criticism to generate engagement.",
+  moral_panic:
+    "Frames issue as urgent moral crisis requiring immediate action.",
+  conspiracy_teaser:
+    "Hints at hidden truth to generate curiosity and distrust.",
+  victim_narrative:
+    "Positions subject as wronged party to generate sympathy and outrage.",
+  call_to_arms:
+    "Explicit mobilization framing for collective action.",
+};
+
+export function computeNarrativeTemplate(
+  template_match?: { template_name: string; confidence: number }
+): NarrativeTemplate | undefined {
+  if (!template_match || template_match.confidence < 0.65) {
+    return undefined;
+  }
+
+  const description =
+    TEMPLATE_DESCRIPTIONS[template_match.template_name] ||
+    "Matches a known viral content template.";
+
+  return {
+    name: template_match.template_name.replace(/_/g, " "),
+    description,
+    confidence: template_match.confidence,
+  };
+}
+
+// ============================================
+// LOW-REGRET ACTION
+// ============================================
+
+export function computeLowRegretAction(
+  input: AsymmetricValueInput,
+  heatVsEvidence: HeatVsEvidence,
+  verificationChecks: [VerificationCheck, VerificationCheck, VerificationCheck]
+): LowRegretAction {
+  const [primaryCheck, dateCheck] = verificationChecks;
+  const { content_type } = input;
+
+  // Priority 1: No primary source
+  if (primaryCheck.status === "no") {
+    if (content_type === "screenshot") {
+      return {
+        action: "Reverse image search or find original",
+        reason:
+          "Screenshots can be edited or taken out of context. Finding the original source is essential.",
+        priority: "high",
+      };
+    }
+    return {
+      action: "Ask for the original source",
+      reason:
+        "Without a primary source, claims cannot be verified. Request the original before engaging.",
+      priority: "high",
+    };
+  }
+
+  // Priority 2: No date context
+  if (dateCheck.status === "no") {
+    return {
+      action: "Check date and full context",
+      reason:
+        "Undated content may be resurfaced or outdated. Verify when this actually happened.",
+      priority: "high",
+    };
+  }
+
+  // Priority 3: High heat-evidence delta
+  if (heatVsEvidence.delta >= 25) {
+    return {
+      action: "Wait 10 minutes, then verify",
+      reason:
+        "High emotional intensity relative to evidence. A brief pause helps bypass the impulse to share.",
+      priority: "medium",
+    };
+  }
+
+  // Priority 4: Partial date context (old content)
+  if (dateCheck.status === "partial") {
+    return {
+      action: "Confirm this is current and relevant",
+      reason:
+        "Content may be dated. Check if the situation has changed since publication.",
+      priority: "medium",
+    };
+  }
+
+  // Default: Read primary source
+  return {
+    action: "Read the primary source first",
+    reason:
+      "Best practice before engaging: read the full original, not just the summary or quote.",
+    priority: "low",
+  };
+}
+
+// ============================================
+// SHARECARD GENERATION
+// ============================================
+
+function getVerificationFlag(
+  verificationChecks: [VerificationCheck, VerificationCheck, VerificationCheck],
+  content_type: string
+): string {
+  const [primaryCheck, dateCheck] = verificationChecks;
+
+  if (content_type === "screenshot") {
+    return "Screenshot risk";
+  }
+  if (primaryCheck.status === "no") {
+    return "No primary source";
+  }
+  if (dateCheck.status === "no") {
+    return "No date context";
+  }
+  if (primaryCheck.status === "partial") {
+    return "Quote w/o link";
+  }
+  if (dateCheck.status === "partial") {
+    return "May be outdated";
+  }
+  return "Verify before sharing";
+}
+
+function getShortAction(lowRegretAction: LowRegretAction): string {
+  const action = lowRegretAction.action;
+  // Truncate to max 6 words
+  const words = action.split(" ");
+  if (words.length <= 6) return action;
+  return words.slice(0, 6).join(" ");
+}
+
+function generateHook(
+  variant: SharecardVariant,
+  forecast: Forecast,
+  heatVsEvidence: HeatVsEvidence
+): string {
+  const { delta } = heatVsEvidence;
+
+  if (variant === "respectful_share") {
+    if (forecast.type === "neutral") {
+      return "Checks out. Worth a read.";
+    }
+    if (delta >= 30) {
+      return "High emotion, low evidence.";
+    }
+    if (delta >= 15) {
+      return "Worth a second look.";
+    }
+    return "Some context to consider.";
+  }
+
+  if (variant === "group_sanity_check") {
+    if (forecast.type === "neutral") {
+      return "This one seems solid.";
+    }
+    if (forecast.type === "impulsive_sharing") {
+      return "Designed for quick shares.";
+    }
+    if (forecast.type === "dunking_dynamics") {
+      return "Pile-on bait detected.";
+    }
+    if (forecast.type === "polarization") {
+      return "Tribal framing in play.";
+    }
+    return "Check before you share.";
+  }
+
+  // direct_warning
+  if (forecast.type === "neutral") {
+    return "Low manipulation signals.";
+  }
+  if (delta >= 40) {
+    return "Strong manipulation pattern.";
+  }
+  if (delta >= 25) {
+    return "Heat exceeds evidence here.";
+  }
+  if (forecast.type === "dunking_dynamics") {
+    return "Sets up a target.";
+  }
+  return "Verification flags present.";
+}
+
+export function generateSharecards(
+  forecast: Forecast,
+  heatVsEvidence: HeatVsEvidence,
+  verificationChecks: [VerificationCheck, VerificationCheck, VerificationCheck],
+  lowRegretAction: LowRegretAction,
+  original_url: string,
+  content_type: string
+): SharecardOutput {
+  const flag = getVerificationFlag(verificationChecks, content_type);
+  const action = getShortAction(lowRegretAction);
+
+  // Extract domain from URL
+  let domain = "unknown";
+  try {
+    domain = new URL(original_url).hostname.replace("www.", "");
+  } catch {
+    domain = "link";
+  }
+
+  const baseContent = {
+    heat_display: `${heatVsEvidence.heat_score}`,
+    evidence_display: `${heatVsEvidence.evidence_score}`,
+    verification_flag: flag,
+    low_regret_action: action,
+    footer_domain: "ragecheck.com",
+    footer_source: domain,
+  };
+
+  const variants: SharecardVariant[] = [
+    "respectful_share",
+    "group_sanity_check",
+    "direct_warning",
+  ];
+
+  const output: SharecardOutput = {} as SharecardOutput;
+
+  for (const variant of variants) {
+    const hook = generateHook(variant, forecast, heatVsEvidence);
+    output[variant] = {
+      ...baseContent,
+      variant,
+      hook,
+    } as SharecardContent;
+  }
+
+  return output;
+}
+
+// ============================================
+// MAIN COMPUTATION
+// ============================================
+
+function hashInput(input: AsymmetricValueInput): string {
+  const str = JSON.stringify({
+    url: input.original_url,
+    text: input.post_text.slice(0, 100),
+    heat: input.language_features.heat_score,
+    evidence: input.language_features.evidence_score,
+  });
+  // Simple hash for deduplication
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+  }
+  return Math.abs(hash).toString(16);
+}
+
+export function computeAsymmetricValue(
+  input: AsymmetricValueInput
+): AsymmetricValueOutput {
+  const { language_features, template_match, content_type } = input;
+
+  // Compute all components
+  const heatVsEvidence = computeHeatVsEvidence(
+    language_features.heat_score,
+    language_features.evidence_score
+  );
+
+  const forecast = computeForecast(
+    language_features.categories,
+    language_features.heat_score,
+    language_features.evidence_score
+  );
+
+  const verificationChecks = computeVerificationChecks(input);
+
+  const incentiveFingerprint = computeIncentiveFingerprint(
+    language_features.categories,
+    language_features.heat_score
+  );
+
+  const narrativeTemplate = computeNarrativeTemplate(template_match);
+
+  const lowRegretAction = computeLowRegretAction(
+    input,
+    heatVsEvidence,
+    verificationChecks
+  );
+
+  return {
+    forecast,
+    heat_vs_evidence: heatVsEvidence,
+    verification_checks: verificationChecks,
+    incentive_fingerprint: incentiveFingerprint,
+    narrative_template: narrativeTemplate,
+    low_regret_action: lowRegretAction,
+    computed_at: new Date().toISOString(),
+    input_hash: hashInput(input),
+  };
+}
+
+// ============================================
+// JSON EXPORT
+// ============================================
+
+export function toJSON(
+  output: AsymmetricValueOutput,
+  sharecards: SharecardOutput
+): AsymmetricValueJSON {
+  return {
+    forecast_text: output.forecast.text,
+    heat_score: output.heat_vs_evidence.heat_score,
+    evidence_score: output.heat_vs_evidence.evidence_score,
+    warning_label: output.heat_vs_evidence.warning_label,
+    verification_checks: output.verification_checks.map((check) => ({
+      label: check.label,
+      status: check.status,
+      detail: check.detail,
+    })),
+    incentive_fingerprint_text: output.incentive_fingerprint.text,
+    template_match_text: output.narrative_template
+      ? `${output.narrative_template.name}: ${output.narrative_template.description}`
+      : undefined,
+    low_regret_action_text: output.low_regret_action.action,
+    sharecard_variants: [
+      {
+        variant: "respectful_share",
+        hook: sharecards.respectful_share.hook,
+        flag: sharecards.respectful_share.verification_flag,
+        action: sharecards.respectful_share.low_regret_action,
+        footer: `${sharecards.respectful_share.footer_domain} | ${sharecards.respectful_share.footer_source}`,
+      },
+      {
+        variant: "group_sanity_check",
+        hook: sharecards.group_sanity_check.hook,
+        flag: sharecards.group_sanity_check.verification_flag,
+        action: sharecards.group_sanity_check.low_regret_action,
+        footer: `${sharecards.group_sanity_check.footer_domain} | ${sharecards.group_sanity_check.footer_source}`,
+      },
+      {
+        variant: "direct_warning",
+        hook: sharecards.direct_warning.hook,
+        flag: sharecards.direct_warning.verification_flag,
+        action: sharecards.direct_warning.low_regret_action,
+        footer: `${sharecards.direct_warning.footer_domain} | ${sharecards.direct_warning.footer_source}`,
+      },
+    ],
+  };
+}

--- a/src/lib/asymmetricValue/types.ts
+++ b/src/lib/asymmetricValue/types.ts
@@ -1,0 +1,188 @@
+/**
+ * Asymmetric Value Analysis Types
+ *
+ * These types define the structured outputs for the Asymmetric Value feature,
+ * which transforms RageCheck from commentary into actionable utility.
+ */
+
+// Input types - what we receive from the analysis
+export type ContentType = "tweet" | "bluesky_post" | "article" | "screenshot" | "other";
+
+export type LanguageCategory =
+  | "enemy_construction"
+  | "betrayal_narrative"
+  | "fear_alert"
+  | "moral_purity_test"
+  | "humiliation"
+  | "status_signal"
+  | "conspiracy_frame"
+  | "doom_loop"
+  | "call_to_punish"
+  | "call_to_share";
+
+export interface Citation {
+  url: string;
+  domain: string;
+  type: "primary" | "secondary" | "unknown";
+}
+
+export interface ExtractedClaim {
+  claim_text: string;
+}
+
+export interface EngagementSignals {
+  likes?: number;
+  reposts?: number;
+  replies?: number;
+}
+
+export interface LanguageFeatures {
+  heat_score: number; // 0-100: emotional intensity
+  evidence_score: number; // 0-100: factual grounding
+  agency_score: number; // 0-100: calls to action
+  ambiguity_score: number; // 0-100: vagueness/uncertainty
+  categories: LanguageCategory[];
+}
+
+export interface TemplateMatch {
+  template_name: string;
+  confidence: number; // 0-1
+}
+
+export interface UserContext {
+  trigger_themes_top3?: string[];
+  heat_drift_7d?: number;
+}
+
+export interface AsymmetricValueInput {
+  content_type: ContentType;
+  original_url: string;
+  author_handle?: string;
+  post_text: string;
+  extracted_claims: ExtractedClaim[];
+  citations_found: Citation[];
+  has_date_context: boolean;
+  detected_date?: string; // ISO string
+  engagement_signals?: EngagementSignals;
+  language_features: LanguageFeatures;
+  template_match?: TemplateMatch;
+  user_context?: UserContext;
+}
+
+// Output types - what we produce
+
+export type ForecastType =
+  | "impulsive_sharing"
+  | "polarization"
+  | "dunking_dynamics"
+  | "anxiety_spiral"
+  | "outgroup_distrust"
+  | "neutral";
+
+export interface Forecast {
+  type: ForecastType;
+  text: string;
+  confidence: "high" | "medium" | "low";
+}
+
+export type VerificationStatus = "yes" | "no" | "partial" | "unknown";
+
+export interface VerificationCheck {
+  label: string;
+  status: VerificationStatus;
+  detail: string;
+}
+
+export type IncentiveAction =
+  | "make you share fast"
+  | "make you distrust an outgroup"
+  | "make you feel morally certain"
+  | "make you join a pile-on"
+  | "make you feel threatened"
+  | "make you punish/ban"
+  | "inform without manipulation";
+
+export interface IncentiveFingerprint {
+  primary_drivers: LanguageCategory[];
+  action: IncentiveAction;
+  beneficiary: string;
+  text: string;
+}
+
+export interface NarrativeTemplate {
+  name: string;
+  description: string;
+  confidence: number;
+}
+
+export interface LowRegretAction {
+  action: string;
+  reason: string;
+  priority: "high" | "medium" | "low";
+}
+
+export interface HeatVsEvidence {
+  heat_score: number;
+  evidence_score: number;
+  delta: number;
+  warning_active: boolean;
+  warning_label?: string;
+  interpretation: string;
+}
+
+// Main output structure
+export interface AsymmetricValueOutput {
+  forecast: Forecast;
+  heat_vs_evidence: HeatVsEvidence;
+  verification_checks: [VerificationCheck, VerificationCheck, VerificationCheck];
+  incentive_fingerprint: IncentiveFingerprint;
+  narrative_template?: NarrativeTemplate;
+  low_regret_action: LowRegretAction;
+
+  // Metadata
+  computed_at: string;
+  input_hash: string;
+}
+
+// Sharecard types
+export type SharecardVariant = "respectful_share" | "group_sanity_check" | "direct_warning";
+
+export interface SharecardContent {
+  variant: SharecardVariant;
+  hook: string; // max 7 words
+  heat_display: string;
+  evidence_display: string;
+  verification_flag: string;
+  low_regret_action: string; // max 6 words
+  footer_domain: string;
+  footer_source: string;
+}
+
+export interface SharecardOutput {
+  respectful_share: SharecardContent;
+  group_sanity_check: SharecardContent;
+  direct_warning: SharecardContent;
+}
+
+// Complete JSON output for API
+export interface AsymmetricValueJSON {
+  forecast_text: string;
+  heat_score: number;
+  evidence_score: number;
+  warning_label?: string;
+  verification_checks: {
+    label: string;
+    status: VerificationStatus;
+    detail: string;
+  }[];
+  incentive_fingerprint_text: string;
+  template_match_text?: string;
+  low_regret_action_text: string;
+  sharecard_variants: {
+    variant: SharecardVariant;
+    hook: string;
+    flag: string;
+    action: string;
+    footer: string;
+  }[];
+}

--- a/src/lib/conversationShape.ts
+++ b/src/lib/conversationShape.ts
@@ -22,12 +22,12 @@ export interface ConversationShape {
 
 // Canonical labels with their display text
 const SHAPE_LABELS: Record<ConversationShapeLabel, string> = {
-  splits_sides: "Conversations split into sides",
-  invites_pileon: "Conversations turn into pile-ons",
-  endless_arguing: "Conversations turn into endless arguing",
-  rewards_stance: "Conversations reward strong stances",
-  spreads_burns: "Spreads fast, then burns out",
-  stays_informational: "Conversations stay mostly informational",
+  splits_sides: "Conversations typically split into sides",
+  invites_pileon: "Conversations typically turn into pile-ons",
+  endless_arguing: "Conversations typically turn into endless arguing",
+  rewards_stance: "Conversations typically reward strong stances",
+  spreads_burns: "Typically spreads fast, then burns out",
+  stays_informational: "Conversations typically stay informational",
 };
 
 const SHAPE_EXPLANATIONS: Record<ConversationShapeLabel, string> = {

--- a/src/lib/conversationShape.ts
+++ b/src/lib/conversationShape.ts
@@ -1,0 +1,272 @@
+/**
+ * Conversation Shape Detection
+ *
+ * Maps detected techniques and triggers to a canonical conversation shape label.
+ * Uses outcome-focused, neutral language - like a weather report.
+ */
+
+export type ConversationShapeLabel =
+  | "splits_sides"
+  | "invites_pileon"
+  | "endless_arguing"
+  | "rewards_stance"
+  | "spreads_burns"
+  | "stays_informational";
+
+export interface ConversationShape {
+  label: ConversationShapeLabel;
+  displayLabel: string;
+  explanation: string;
+  microSignals: string[];
+}
+
+// Canonical labels with their display text
+const SHAPE_LABELS: Record<ConversationShapeLabel, string> = {
+  splits_sides: "This splits people into sides",
+  invites_pileon: "This invites a pile-on",
+  endless_arguing: "This turns into endless arguing",
+  rewards_stance: "This rewards taking a strong stance",
+  spreads_burns: "This spreads fast, then burns out",
+  stays_informational: "This stays mostly informational",
+};
+
+const SHAPE_EXPLANATIONS: Record<ConversationShapeLabel, string> = {
+  splits_sides:
+    "Content like this tends to sort people into opposing camps, with each side reinforcing its own view.",
+  invites_pileon:
+    "This framing tends to draw collective criticism toward a target, often escalating quickly.",
+  endless_arguing:
+    "Threads on content like this often loop without resolution, with participants talking past each other.",
+  rewards_stance:
+    "Engagement tends to flow toward those who take the strongest position, regardless of nuance.",
+  spreads_burns:
+    "High initial sharing followed by rapid decline as the emotional charge fades.",
+  stays_informational:
+    "Discussion tends to focus on facts and context rather than emotional reactions.",
+};
+
+interface SignalBreakdown {
+  arousal: number;
+  enemy_construction: number;
+  moral_condemnation: number;
+  simplification: number;
+  call_to_conflict: number;
+}
+
+interface DetectionInput {
+  signalBreakdown: SignalBreakdown;
+  techniqueExplanations?: string[];
+  sharingPatterns?: string[];
+  score?: number;
+}
+
+/**
+ * Detect conversation shape from analysis signals
+ *
+ * Priority order:
+ * 1. High enemy construction + moral condemnation → splits_sides
+ * 2. High call to conflict + enemy construction → invites_pileon
+ * 3. High simplification + moderate arousal → endless_arguing
+ * 4. High moral condemnation + moderate conflict → rewards_stance
+ * 5. High arousal + low evidence patterns → spreads_burns
+ * 6. Low overall signals → stays_informational
+ */
+export function detectConversationShape(input: DetectionInput): ConversationShape {
+  const { signalBreakdown, techniqueExplanations = [], sharingPatterns = [], score = 0 } = input;
+  const techniques = techniqueExplanations.join(" ").toLowerCase();
+  const patterns = sharingPatterns.join(" ").toLowerCase();
+  const combined = techniques + " " + patterns;
+
+  // Helper to check for keywords
+  const hasKeyword = (keywords: string[]) =>
+    keywords.some((k) => combined.includes(k.toLowerCase()));
+
+  // Calculate composite scores
+  const threatIdentityScore =
+    signalBreakdown.enemy_construction * 0.4 +
+    signalBreakdown.moral_condemnation * 0.4 +
+    signalBreakdown.arousal * 0.2;
+
+  const pileonScore =
+    signalBreakdown.call_to_conflict * 0.5 +
+    signalBreakdown.enemy_construction * 0.3 +
+    signalBreakdown.moral_condemnation * 0.2;
+
+  const arguingScore =
+    signalBreakdown.simplification * 0.4 +
+    signalBreakdown.moral_condemnation * 0.3 +
+    signalBreakdown.arousal * 0.3;
+
+  const stanceScore =
+    signalBreakdown.moral_condemnation * 0.5 +
+    signalBreakdown.enemy_construction * 0.3 +
+    signalBreakdown.call_to_conflict * 0.2;
+
+  const viralBurnScore =
+    signalBreakdown.arousal * 0.5 +
+    signalBreakdown.call_to_conflict * 0.3 +
+    signalBreakdown.simplification * 0.2;
+
+  // Build micro-signals based on what's detected
+  const buildMicroSignals = (shape: ConversationShapeLabel): string[] => {
+    const signals: string[] = [];
+
+    if (shape === "splits_sides") {
+      if (signalBreakdown.enemy_construction >= 40)
+        signals.push("Uses us-vs-them framing");
+      if (signalBreakdown.moral_condemnation >= 40)
+        signals.push("Activates moral certainty");
+      if (signalBreakdown.arousal >= 50 || hasKeyword(["threat", "fear", "danger"]))
+        signals.push("Heightens sense of threat");
+      if (hasKeyword(["identity", "group", "tribe", "real"]))
+        signals.push("Engages group identity");
+    }
+
+    if (shape === "invites_pileon") {
+      if (signalBreakdown.call_to_conflict >= 40)
+        signals.push("Frames target for criticism");
+      if (hasKeyword(["outrage", "unacceptable", "disgrace"]))
+        signals.push("Uses outrage framing");
+      if (signalBreakdown.enemy_construction >= 40)
+        signals.push("Constructs a clear villain");
+      if (hasKeyword(["punish", "accountable", "consequences"]))
+        signals.push("Suggests collective response");
+    }
+
+    if (shape === "endless_arguing") {
+      if (signalBreakdown.simplification >= 40)
+        signals.push("Oversimplifies complex issue");
+      if (hasKeyword(["status", "signal", "virtue"]))
+        signals.push("Rewards status signaling");
+      if (signalBreakdown.moral_condemnation >= 30)
+        signals.push("Frames as moral question");
+    }
+
+    if (shape === "rewards_stance") {
+      if (signalBreakdown.moral_condemnation >= 50)
+        signals.push("Rewards moral certainty");
+      if (hasKeyword(["identity", "stand", "believe"]))
+        signals.push("Ties to identity expression");
+      if (signalBreakdown.simplification >= 40)
+        signals.push("Favors clear positions");
+    }
+
+    if (shape === "spreads_burns") {
+      if (signalBreakdown.arousal >= 60)
+        signals.push("High emotional charge");
+      if (hasKeyword(["urgent", "breaking", "just in"]))
+        signals.push("Creates urgency to share");
+      if (hasKeyword(["fear", "shocking", "unbelievable"]))
+        signals.push("Novelty-driven engagement");
+    }
+
+    if (shape === "stays_informational") {
+      if (signalBreakdown.arousal < 30)
+        signals.push("Low emotional intensity");
+      if (signalBreakdown.simplification < 30)
+        signals.push("Preserves context and nuance");
+      if (score !== undefined && score < 35)
+        signals.push("Minimal persuasion signals");
+    }
+
+    // Return top 3 signals
+    return signals.slice(0, 3);
+  };
+
+  // Decision logic - check in priority order
+  let selectedShape: ConversationShapeLabel;
+
+  // Check for low overall signals first (informational)
+  if (
+    score < 30 &&
+    signalBreakdown.arousal < 30 &&
+    signalBreakdown.enemy_construction < 25 &&
+    signalBreakdown.call_to_conflict < 25
+  ) {
+    selectedShape = "stays_informational";
+  }
+  // High enemy construction + moral condemnation → splits sides
+  else if (
+    threatIdentityScore >= 50 &&
+    signalBreakdown.enemy_construction >= 35 &&
+    signalBreakdown.moral_condemnation >= 30
+  ) {
+    selectedShape = "splits_sides";
+  }
+  // High call to conflict + enemy construction → pile-on
+  else if (
+    pileonScore >= 50 &&
+    signalBreakdown.call_to_conflict >= 40 &&
+    (hasKeyword(["punish", "accountable", "villain", "disgrace"]) ||
+      signalBreakdown.enemy_construction >= 40)
+  ) {
+    selectedShape = "invites_pileon";
+  }
+  // High arousal + urgency keywords → spreads fast, burns out
+  else if (
+    viralBurnScore >= 55 &&
+    signalBreakdown.arousal >= 50 &&
+    (hasKeyword(["urgent", "breaking", "fear", "shocking"]) ||
+      signalBreakdown.simplification >= 40)
+  ) {
+    selectedShape = "spreads_burns";
+  }
+  // High moral condemnation + identity → rewards stance
+  else if (
+    stanceScore >= 45 &&
+    signalBreakdown.moral_condemnation >= 40 &&
+    (hasKeyword(["identity", "stand", "believe", "values"]) ||
+      signalBreakdown.enemy_construction >= 30)
+  ) {
+    selectedShape = "rewards_stance";
+  }
+  // Moderate signals with simplification → endless arguing
+  else if (
+    arguingScore >= 40 &&
+    signalBreakdown.simplification >= 35 &&
+    score >= 30
+  ) {
+    selectedShape = "endless_arguing";
+  }
+  // High arousal without clear pattern → spreads fast
+  else if (viralBurnScore >= 45 && signalBreakdown.arousal >= 45) {
+    selectedShape = "spreads_burns";
+  }
+  // Default based on highest composite
+  else {
+    const scores = [
+      { shape: "splits_sides" as const, score: threatIdentityScore },
+      { shape: "invites_pileon" as const, score: pileonScore },
+      { shape: "endless_arguing" as const, score: arguingScore },
+      { shape: "rewards_stance" as const, score: stanceScore },
+      { shape: "spreads_burns" as const, score: viralBurnScore },
+    ];
+
+    const highest = scores.reduce((a, b) => (a.score > b.score ? a : b));
+
+    if (highest.score >= 35) {
+      selectedShape = highest.shape;
+    } else {
+      selectedShape = "stays_informational";
+    }
+  }
+
+  return {
+    label: selectedShape,
+    displayLabel: SHAPE_LABELS[selectedShape],
+    explanation: SHAPE_EXPLANATIONS[selectedShape],
+    microSignals: buildMicroSignals(selectedShape),
+  };
+}
+
+/**
+ * Get structured output for API
+ */
+export function getConversationShapeJSON(shape: ConversationShape) {
+  return {
+    conversation_shape_label: shape.label,
+    conversation_shape_display: shape.displayLabel,
+    conversation_shape_explanation: shape.explanation,
+    conversation_shape_signals: shape.microSignals,
+  };
+}

--- a/src/lib/conversationShape.ts
+++ b/src/lib/conversationShape.ts
@@ -22,12 +22,12 @@ export interface ConversationShape {
 
 // Canonical labels with their display text
 const SHAPE_LABELS: Record<ConversationShapeLabel, string> = {
-  splits_sides: "Conversations typically split into sides",
-  invites_pileon: "Conversations typically turn into pile-ons",
-  endless_arguing: "Conversations typically turn into endless arguing",
-  rewards_stance: "Conversations typically reward strong stances",
-  spreads_burns: "Typically spreads fast, then burns out",
-  stays_informational: "Conversations typically stay informational",
+  splits_sides: "Conversations tend to split into sides",
+  invites_pileon: "Conversations tend to turn into pile-ons",
+  endless_arguing: "Conversations tend to turn into endless arguing",
+  rewards_stance: "Conversations tend to reward strong stances",
+  spreads_burns: "Tends to spread fast, then burn out",
+  stays_informational: "Conversations tend to stay informational",
 };
 
 const SHAPE_EXPLANATIONS: Record<ConversationShapeLabel, string> = {

--- a/src/lib/conversationShape.ts
+++ b/src/lib/conversationShape.ts
@@ -22,12 +22,12 @@ export interface ConversationShape {
 
 // Canonical labels with their display text
 const SHAPE_LABELS: Record<ConversationShapeLabel, string> = {
-  splits_sides: "Conversations tend to split into sides",
-  invites_pileon: "Conversations tend to turn into pile-ons",
-  endless_arguing: "Conversations tend to turn into endless arguing",
-  rewards_stance: "Conversations tend to reward strong stances",
+  splits_sides: "Tends to split people into sides",
+  invites_pileon: "Tends to invite pile-ons",
+  endless_arguing: "Tends to turn into endless arguing",
+  rewards_stance: "Tends to reward strong stances",
   spreads_burns: "Tends to spread fast, then burn out",
-  stays_informational: "Conversations tend to stay informational",
+  stays_informational: "Tends to stay informational",
 };
 
 const SHAPE_EXPLANATIONS: Record<ConversationShapeLabel, string> = {

--- a/src/lib/conversationShape.ts
+++ b/src/lib/conversationShape.ts
@@ -32,17 +32,17 @@ const SHAPE_LABELS: Record<ConversationShapeLabel, string> = {
 
 const SHAPE_EXPLANATIONS: Record<ConversationShapeLabel, string> = {
   splits_sides:
-    "Content like this tends to sort people into opposing camps, with each side reinforcing its own view.",
+    "People tend to pick a team and dig in. Each side talks mostly to itself.",
   invites_pileon:
-    "This framing tends to draw collective criticism toward a target, often escalating quickly.",
+    "There's a clear target, and criticism tends to snowball fast.",
   endless_arguing:
-    "Threads on content like this often loop without resolution, with participants talking past each other.",
+    "Comments go in circles. People talk past each other without anyone changing their mind.",
   rewards_stance:
-    "Engagement tends to flow toward those who take the strongest position, regardless of nuance.",
+    "The strongest takes get the most attention, whether or not they're right.",
   spreads_burns:
-    "High initial sharing followed by rapid decline as the emotional charge fades.",
+    "Gets shared a lot at first, then fades once the emotional charge wears off.",
   stays_informational:
-    "Discussion tends to focus on facts and context rather than emotional reactions.",
+    "Replies tend to stay on topic and focus on the actual facts.",
 };
 
 interface SignalBreakdown {
@@ -113,60 +113,60 @@ export function detectConversationShape(input: DetectionInput): ConversationShap
 
     if (shape === "splits_sides") {
       if (signalBreakdown.enemy_construction >= 40)
-        signals.push("Uses us-vs-them framing");
+        signals.push("Sets up an 'us vs them'");
       if (signalBreakdown.moral_condemnation >= 40)
-        signals.push("Activates moral certainty");
+        signals.push("Makes it feel like a moral issue");
       if (signalBreakdown.arousal >= 50 || hasKeyword(["threat", "fear", "danger"]))
-        signals.push("Heightens sense of threat");
+        signals.push("Plays up a sense of threat");
       if (hasKeyword(["identity", "group", "tribe", "real"]))
-        signals.push("Engages group identity");
+        signals.push("Ties into group identity");
     }
 
     if (shape === "invites_pileon") {
       if (signalBreakdown.call_to_conflict >= 40)
-        signals.push("Frames target for criticism");
+        signals.push("Points at someone to criticize");
       if (hasKeyword(["outrage", "unacceptable", "disgrace"]))
-        signals.push("Uses outrage framing");
+        signals.push("Frames it as outrageous");
       if (signalBreakdown.enemy_construction >= 40)
-        signals.push("Constructs a clear villain");
+        signals.push("Paints a clear villain");
       if (hasKeyword(["punish", "accountable", "consequences"]))
-        signals.push("Suggests collective response");
+        signals.push("Hints that 'something should be done'");
     }
 
     if (shape === "endless_arguing") {
       if (signalBreakdown.simplification >= 40)
-        signals.push("Oversimplifies complex issue");
+        signals.push("Flattens a complex issue");
       if (hasKeyword(["status", "signal", "virtue"]))
-        signals.push("Rewards status signaling");
+        signals.push("Rewards strong opinions over nuance");
       if (signalBreakdown.moral_condemnation >= 30)
-        signals.push("Frames as moral question");
+        signals.push("Turns it into a right-vs-wrong debate");
     }
 
     if (shape === "rewards_stance") {
       if (signalBreakdown.moral_condemnation >= 50)
-        signals.push("Rewards moral certainty");
+        signals.push("Rewards being sure of yourself");
       if (hasKeyword(["identity", "stand", "believe"]))
-        signals.push("Ties to identity expression");
+        signals.push("Makes your take feel like your identity");
       if (signalBreakdown.simplification >= 40)
-        signals.push("Favors clear positions");
+        signals.push("Favors bold, simple positions");
     }
 
     if (shape === "spreads_burns") {
       if (signalBreakdown.arousal >= 60)
         signals.push("High emotional charge");
       if (hasKeyword(["urgent", "breaking", "just in"]))
-        signals.push("Creates urgency to share");
+        signals.push("Feels urgent to share now");
       if (hasKeyword(["fear", "shocking", "unbelievable"]))
-        signals.push("Novelty-driven engagement");
+        signals.push("Novelty grabs attention");
     }
 
     if (shape === "stays_informational") {
       if (signalBreakdown.arousal < 30)
-        signals.push("Low emotional intensity");
+        signals.push("Low emotional heat");
       if (signalBreakdown.simplification < 30)
-        signals.push("Preserves context and nuance");
+        signals.push("Keeps the nuance intact");
       if (score !== undefined && score < 35)
-        signals.push("Minimal persuasion signals");
+        signals.push("Not trying hard to persuade");
     }
 
     // Return top 3 signals

--- a/src/lib/conversationShape.ts
+++ b/src/lib/conversationShape.ts
@@ -22,12 +22,12 @@ export interface ConversationShape {
 
 // Canonical labels with their display text
 const SHAPE_LABELS: Record<ConversationShapeLabel, string> = {
-  splits_sides: "This splits people into sides",
-  invites_pileon: "This invites a pile-on",
-  endless_arguing: "This turns into endless arguing",
-  rewards_stance: "This rewards taking a strong stance",
-  spreads_burns: "This spreads fast, then burns out",
-  stays_informational: "This stays mostly informational",
+  splits_sides: "Conversations split into sides",
+  invites_pileon: "Conversations turn into pile-ons",
+  endless_arguing: "Conversations turn into endless arguing",
+  rewards_stance: "Conversations reward strong stances",
+  spreads_burns: "Spreads fast, then burns out",
+  stays_informational: "Conversations stay mostly informational",
 };
 
 const SHAPE_EXPLANATIONS: Record<ConversationShapeLabel, string> = {

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -87,8 +87,7 @@ Respond with this exact JSON structure:
   "reasons": [<3-5 concise bullet points explaining the score>],
   "contextNotes": "<optional: note if rule-based score was misleading due to context>",
   "sharingPatterns": [<2-3 reasons why people share this. Use plain everyday language a teenager would understand. NO jargon. e.g. "Confirms what many already suspect about X", "Makes readers feel part of a group who 'gets it'", "The outrage feels satisfying to pass along">],
-  "techniqueExplanations": [<2-3 things to notice about how it's written. Use plain everyday words - NO academic labels like "Framing" or "Rhetoric". Just describe what's happening. e.g. "Plays on fear: Makes the threat feel urgent so you react before thinking", "Loaded words: Uses emotional language to make ordinary things seem worse", "Quotes without context: Cherry-picks what someone said to change the meaning">],
-  "shareCardSummary": "<ONE crisp 6-10 word observation about the writing style. Don't mention the topic. Sound smart but accessible. e.g. 'Heavy on emotion, light on facts' or 'More heat than light' or 'Straightforward, minimal spin' or 'Leans hard on loaded language'>"
+  "techniqueExplanations": [<2-3 things to notice about how it's written. Use plain everyday words - NO academic labels like "Framing" or "Rhetoric". Just describe what's happening. e.g. "Plays on fear: Makes the threat feel urgent so you react before thinking", "Loaded words: Uses emotional language to make ordinary things seem worse", "Quotes without context: Cherry-picks what someone said to change the meaning">]
 }`;
 
   try {
@@ -188,8 +187,7 @@ Respond with this exact JSON structure:
   "reasons": [<3-5 concise bullet points explaining the score>],
   "highlights": [{"text": "<problematic phrase>", "category": "<signal category>"}],
   "sharingPatterns": [<2-3 reasons why people share this. Plain everyday language, NO jargon>],
-  "techniqueExplanations": [<2-3 things to notice about how it's written. Plain words, NO academic labels>],
-  "shareCardSummary": "<ONE crisp 6-10 word observation about the writing style. Don't mention the topic. Sound smart but accessible.>"
+  "techniqueExplanations": [<2-3 things to notice about how it's written. Plain words, NO academic labels>]
 }`;
 
 export async function analyzeImageWithVision(

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -88,7 +88,7 @@ Respond with this exact JSON structure:
   "contextNotes": "<optional: note if rule-based score was misleading due to context>",
   "sharingPatterns": [<2-3 reasons why people share this. Use plain everyday language a teenager would understand. NO jargon. e.g. "Confirms what many already suspect about X", "Makes readers feel part of a group who 'gets it'", "The outrage feels satisfying to pass along">],
   "techniqueExplanations": [<2-3 things to notice about how it's written. Use plain everyday words - NO academic labels like "Framing" or "Rhetoric". Just describe what's happening. e.g. "Plays on fear: Makes the threat feel urgent so you react before thinking", "Loaded words: Uses emotional language to make ordinary things seem worse", "Quotes without context: Cherry-picks what someone said to change the meaning">],
-  "shareCardSummary": "<ONE punchy 8-12 word sentence summarizing the manipulation verdict for social sharing, e.g. 'Uses fear framing to bypass critical thinking' or 'Straightforward reporting with minimal emotional spin'>"
+  "shareCardSummary": "<ONE simple 8-12 word sentence an 8th grader would understand. What's the main thing to know? e.g. 'Tries to make you angry before you think' or 'Pretty straightforward, not trying to push buttons'>"
 }`;
 
   try {
@@ -189,7 +189,7 @@ Respond with this exact JSON structure:
   "highlights": [{"text": "<problematic phrase>", "category": "<signal category>"}],
   "sharingPatterns": [<2-3 reasons why people share this. Plain everyday language, NO jargon>],
   "techniqueExplanations": [<2-3 things to notice about how it's written. Plain words, NO academic labels>],
-  "shareCardSummary": "<ONE punchy 8-12 word sentence summarizing the verdict for social sharing>"
+  "shareCardSummary": "<ONE simple 8-12 word sentence an 8th grader would understand. What's the main thing to know?>"
 }`;
 
 export async function analyzeImageWithVision(

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -88,7 +88,7 @@ Respond with this exact JSON structure:
   "contextNotes": "<optional: note if rule-based score was misleading due to context>",
   "sharingPatterns": [<2-3 reasons why people share this. Use plain everyday language a teenager would understand. NO jargon. e.g. "Confirms what many already suspect about X", "Makes readers feel part of a group who 'gets it'", "The outrage feels satisfying to pass along">],
   "techniqueExplanations": [<2-3 things to notice about how it's written. Use plain everyday words - NO academic labels like "Framing" or "Rhetoric". Just describe what's happening. e.g. "Plays on fear: Makes the threat feel urgent so you react before thinking", "Loaded words: Uses emotional language to make ordinary things seem worse", "Quotes without context: Cherry-picks what someone said to change the meaning">],
-  "shareCardSummary": "<ONE simple 8-12 word sentence an 8th grader would understand. What's the main thing to know? e.g. 'Tries to make you angry before you think' or 'Pretty straightforward, not trying to push buttons'>"
+  "shareCardSummary": "<ONE simple 8-12 word sentence about the MANIPULATION LEVEL, not the article topic. Is it trying to push your buttons or not? e.g. 'Tries to make you angry before you think' or 'Pretty straightforward, not pushing buttons'>"
 }`;
 
   try {
@@ -189,7 +189,7 @@ Respond with this exact JSON structure:
   "highlights": [{"text": "<problematic phrase>", "category": "<signal category>"}],
   "sharingPatterns": [<2-3 reasons why people share this. Plain everyday language, NO jargon>],
   "techniqueExplanations": [<2-3 things to notice about how it's written. Plain words, NO academic labels>],
-  "shareCardSummary": "<ONE simple 8-12 word sentence an 8th grader would understand. What's the main thing to know?>"
+  "shareCardSummary": "<ONE simple 8-12 word sentence about the MANIPULATION LEVEL, not the content topic. Is it pushing buttons or not?>"
 }`;
 
 export async function analyzeImageWithVision(

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -86,8 +86,8 @@ Respond with this exact JSON structure:
   "adjustedScore": <number 0-100, adjust rule-based score based on context>,
   "reasons": [<3-5 concise bullet points explaining the score>],
   "contextNotes": "<optional: note if rule-based score was misleading due to context>",
-  "sharingPatterns": [<2-3 reasons why people share this, in plain conversational English. e.g. "Confirms what many already suspect about X", "Makes readers feel part of a group who 'gets it'", "The outrage feels satisfying to pass along">],
-  "techniqueExplanations": [<2-3 specific techniques used, explained simply. Start with a short label, then explain like you're telling a friend. e.g. "Playing on fear: Makes a threat feel urgent so you react before thinking", "Loaded words: Describes ordinary things using emotional language to make them seem worse">],
+  "sharingPatterns": [<2-3 reasons why people share this. Use plain everyday language a teenager would understand. NO jargon. e.g. "Confirms what many already suspect about X", "Makes readers feel part of a group who 'gets it'", "The outrage feels satisfying to pass along">],
+  "techniqueExplanations": [<2-3 things to notice about how it's written. Use plain everyday words - NO academic labels like "Framing" or "Rhetoric". Just describe what's happening. e.g. "Plays on fear: Makes the threat feel urgent so you react before thinking", "Loaded words: Uses emotional language to make ordinary things seem worse", "Quotes without context: Cherry-picks what someone said to change the meaning">],
   "shareCardSummary": "<ONE punchy 8-12 word sentence summarizing the manipulation verdict for social sharing, e.g. 'Uses fear framing to bypass critical thinking' or 'Straightforward reporting with minimal emotional spin'>"
 }`;
 
@@ -187,8 +187,8 @@ Respond with this exact JSON structure:
   },
   "reasons": [<3-5 concise bullet points explaining the score>],
   "highlights": [{"text": "<problematic phrase>", "category": "<signal category>"}],
-  "sharingPatterns": [<2-3 reasons why people share this, in plain conversational English>],
-  "techniqueExplanations": [<2-3 specific techniques used, explained simply like you're telling a friend>],
+  "sharingPatterns": [<2-3 reasons why people share this. Plain everyday language, NO jargon>],
+  "techniqueExplanations": [<2-3 things to notice about how it's written. Plain words, NO academic labels>],
   "shareCardSummary": "<ONE punchy 8-12 word sentence summarizing the verdict for social sharing>"
 }`;
 

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -86,8 +86,8 @@ Respond with this exact JSON structure:
   "adjustedScore": <number 0-100, adjust rule-based score based on context>,
   "reasons": [<3-5 concise bullet points explaining the score>],
   "contextNotes": "<optional: note if rule-based score was misleading due to context>",
-  "sharingPatterns": [<2-3 reasons why content like this tends to spread, e.g. "Validates pre-existing fears about X", "Creates strong in-group identification", "Outrage drives more engagement than nuance">],
-  "techniqueExplanations": [<2-3 specific manipulation techniques used, with brief explanations, e.g. "Fear appeal: Uses threat of harm to bypass rational evaluation", "Loaded framing: Describes neutral facts using emotionally charged language">],
+  "sharingPatterns": [<2-3 reasons why people share this, in plain conversational English. e.g. "Confirms what many already suspect about X", "Makes readers feel part of a group who 'gets it'", "The outrage feels satisfying to pass along">],
+  "techniqueExplanations": [<2-3 specific techniques used, explained simply. Start with a short label, then explain like you're telling a friend. e.g. "Playing on fear: Makes a threat feel urgent so you react before thinking", "Loaded words: Describes ordinary things using emotional language to make them seem worse">],
   "shareCardSummary": "<ONE punchy 8-12 word sentence summarizing the manipulation verdict for social sharing, e.g. 'Uses fear framing to bypass critical thinking' or 'Straightforward reporting with minimal emotional spin'>"
 }`;
 
@@ -187,8 +187,8 @@ Respond with this exact JSON structure:
   },
   "reasons": [<3-5 concise bullet points explaining the score>],
   "highlights": [{"text": "<problematic phrase>", "category": "<signal category>"}],
-  "sharingPatterns": [<2-3 reasons why this content spreads>],
-  "techniqueExplanations": [<2-3 specific manipulation techniques used>],
+  "sharingPatterns": [<2-3 reasons why people share this, in plain conversational English>],
+  "techniqueExplanations": [<2-3 specific techniques used, explained simply like you're telling a friend>],
   "shareCardSummary": "<ONE punchy 8-12 word sentence summarizing the verdict for social sharing>"
 }`;
 

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -88,7 +88,7 @@ Respond with this exact JSON structure:
   "contextNotes": "<optional: note if rule-based score was misleading due to context>",
   "sharingPatterns": [<2-3 reasons why people share this. Use plain everyday language a teenager would understand. NO jargon. e.g. "Confirms what many already suspect about X", "Makes readers feel part of a group who 'gets it'", "The outrage feels satisfying to pass along">],
   "techniqueExplanations": [<2-3 things to notice about how it's written. Use plain everyday words - NO academic labels like "Framing" or "Rhetoric". Just describe what's happening. e.g. "Plays on fear: Makes the threat feel urgent so you react before thinking", "Loaded words: Uses emotional language to make ordinary things seem worse", "Quotes without context: Cherry-picks what someone said to change the meaning">],
-  "shareCardSummary": "<ONE simple 8-12 word sentence about the MANIPULATION LEVEL, not the article topic. Is it trying to push your buttons or not? e.g. 'Tries to make you angry before you think' or 'Pretty straightforward, not pushing buttons'>"
+  "shareCardSummary": "<ONE crisp 6-10 word observation about the writing style. Don't mention the topic. Sound smart but accessible. e.g. 'Heavy on emotion, light on facts' or 'More heat than light' or 'Straightforward, minimal spin' or 'Leans hard on loaded language'>"
 }`;
 
   try {
@@ -189,7 +189,7 @@ Respond with this exact JSON structure:
   "highlights": [{"text": "<problematic phrase>", "category": "<signal category>"}],
   "sharingPatterns": [<2-3 reasons why people share this. Plain everyday language, NO jargon>],
   "techniqueExplanations": [<2-3 things to notice about how it's written. Plain words, NO academic labels>],
-  "shareCardSummary": "<ONE simple 8-12 word sentence about the MANIPULATION LEVEL, not the content topic. Is it pushing buttons or not?>"
+  "shareCardSummary": "<ONE crisp 6-10 word observation about the writing style. Don't mention the topic. Sound smart but accessible.>"
 }`;
 
 export async function analyzeImageWithVision(

--- a/src/lib/score.ts
+++ b/src/lib/score.ts
@@ -52,11 +52,11 @@ const CATEGORY_DESCRIPTIONS: Record<SignalCategory, string> = {
 
 // Canonical signal labels for UI display
 export const SIGNAL_LABELS: Record<SignalCategory, string> = {
-  arousal: "Emotional Arousal",
-  enemy_construction: "Enemy Construction",
-  moral_condemnation: "Moral Condemnation",
-  simplification: "Oversimplification",
-  call_to_conflict: "Call-to-Conflict",
+  arousal: "Emotional Heat",
+  enemy_construction: "Us vs Them",
+  moral_condemnation: "Moral Outrage",
+  simplification: "Black & White Thinking",
+  call_to_conflict: "Fight-Picking",
 };
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/__tests__/**"]
 }


### PR DESCRIPTION
## Summary

- Added "What Follows" section showing predicted conversation patterns (splits_sides, invites_pileon, etc.)
- Renamed signal categories to plain English: Emotional Heat, Us vs Them, Moral Outrage, Black & White Thinking, Fight-Picking
- Made LLM prompts produce more accessible, jargon-free explanations
- Unified list formatting across all analysis sections
- Updated Methodology page with conceptual framework

## Removed

- ShareCardSummary feature (couldn't get the tone right - kept oscillating between too academic and too simple)

## Test plan

- [ ] Analyze a high-rage article - verify all sections display correctly
- [ ] Check signal category names appear in UI
- [ ] Verify "What Follows" section shows with micro-signals
- [ ] Test image upload still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)